### PR TITLE
ignore local folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ workspace.xml
 /validator/out/
 /pubber/build/
 /sites/
+/local/


### PR DESCRIPTION
The `local` folder is meant to have configuration specific files, can it be added to .gitignore?