### PR TITLE
auth application-default login line

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,12 +1,13 @@
 # UDMI Validation Workflow
 
 The overall UDMI project validation workflow generally looks like this:
-1. Setup a [`site_model`](site_model.md) in a git repo with appropriate configuration and metadata.
-2. Run [`registrar`](registrar.md) with no specified project to validate metadata.
-3. Use [`keygen`](keygen.md) as necessary to generate keys.
-4. Run `registrar` tool again with a cloud project to actually register devices.
-5. Do the needful to get data flowing from devices.
-6. Run [`validator`](validator.md) to validate that the devices are producing the correct data.
+1. Login to the GCP account using `gcloud auth application-default login`
+2. Setup a [`site_model`](site_model.md) in a git repo with appropriate configuration and metadata.
+3. Run [`registrar`](registrar.md) with no specified project to validate metadata.
+4. Use [`keygen`](keygen.md) as necessary to generate keys.
+5. Run `registrar` tool again with a cloud project to actually register devices.
+6. Do the needful to get data flowing from devices.
+7. Run [`validator`](validator.md) to validate that the devices are producing the correct data.
 
 It is strongly recommended to go through all of these steps with one or two test devices,
 rather than trying to take on an entire site without fully vetting the workflow and tools.


### PR DESCRIPTION
I think it's a good idea to add this line to the workflow instructions.
Without this specific way to login, the following error pops up.
```
...
Initializing with default credentials...
Oct 18, 2020 6:13:36 PM com.google.auth.oauth2.ComputeEngineCredentials runningOnComputeEngine
INFO: Failed to detect whether we are running on Google Compute Engine.
java.lang.RuntimeException: While initializing Cloud IoT project projects/iot-workshop-2020/locations/europe-west1
	at com.google.daq.mqtt.util.CloudIotManager.initializeCloudIoT(CloudIotManager.java:94)
	at com.google.daq.mqtt.util.CloudIotManager.<init>(CloudIotManager.java:61)
	at com.google.daq.mqtt.registrar.Registrar.initializeCloudProject(Registrar.java:136)
	at com.google.daq.mqtt.registrar.Registrar.setProjectId(Registrar.java:373)
	at com.google.daq.mqtt.registrar.Registrar.main(Registrar.java:80)
Caused by: java.io.IOException: The Application Default Credentials are not available. They are available if running in Google Compute Engine. Otherwise, the environment variable GOOGLE_APPLICATION_CREDENTIALS must be defined pointing to a file defining the credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
	at com.google.auth.oauth2.DefaultCredentialsProvider.getDefaultCredentials(DefaultCredentialsProvider.java:132)
	at com.google.auth.oauth2.GoogleCredentials.getApplicationDefault(GoogleCredentials.java:127)
	at com.google.auth.oauth2.GoogleCredentials.getApplicationDefault(GoogleCredentials.java:100)
	at com.google.daq.mqtt.util.CloudIotManager.initializeCloudIoT(CloudIotManager.java:84)
	... 4 more

...
```