### PR TITLE
fix x509 cert generation error

### DIFF
--- a/bin/keygen
+++ b/bin/keygen
@@ -12,11 +12,15 @@ if [ $type == RS256 ]; then
     openssl genrsa -out rsa_private.pem 2048
     openssl rsa -in rsa_private.pem -pubout -out rsa_public.pem
 elif [ $type == RS256_X509 ]; then
+    openssl genrsa -out rsa_private.pem 2048
+    openssl rsa -in rsa_private.pem -pubout -out rsa_public.pem
     openssl req -x509 -nodes -newkey rsa:2048 -keyout rsa_private.pem -days 1000000 -out rsa_cert.pem -subj "/CN=unused"
 elif [ $type == ES256 ]; then
     openssl ecparam -genkey -name prime256v1 -noout -out ec_private.pem
     openssl ec -in ec_private.pem -pubout -out ec_public.pem
 elif [ $type == ES256_X509 ]; then
+    openssl ecparam -genkey -name prime256v1 -noout -out ec_private.pem
+    openssl ec -in ec_private.pem -pubout -out ec_public.pem
     openssl req -x509 -new -key ec_private.pem -out ec_cert.pem -days 1000000 -subj "/CN=unused"
 else
     echo Unknown key type $type. Try one of { RS256, RS256_X509, ES256, ES256_X509 }


### PR DESCRIPTION
the x509 cert generation needs to happen after the keys have been generated, so the _X509 type options need to also include the keys generation