### PR TITLE
Update metadata_cloud.json

### DIFF
--- a/schema/metadata_cloud.json
+++ b/schema/metadata_cloud.json
@@ -7,9 +7,9 @@
     "auth_type": {
       "enum": [
         "ES256",
-        "ES256_X506",
+        "ES256_X509",
         "RS256",
-        "RS256_X506"
+        "RS256_X509"
       ]
     },
     "is_gateway": {


### PR DESCRIPTION
I get an error in the error.json file when registering the devices, because it expects RS256_X506, but RS256_X509 is the correct name for creating the keys.