### PR TITLE
adding updated pyudmi to contrib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,5 @@ firebase-debug.log
 /venv/
 /local/
 
-/contrib/pyudmi/build/
-/contrib/pyudmi/src/udmi/schema/
-/contrib/pyudmi/dist/
-/contrib/pyudmi/pyudmi.egg-info/
-
 .DS_Store
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ firebase-debug.log
 /attributes.json
 /venv/
 /local/
+
+/contrib/pyudmi/build/
+/contrib/pyudmi/src/udmi/schema/
+/contrib/pyudmi/dist/
+/contrib/pyudmi/pyudmi.egg-info/
+
+.DS_Store
+.idea/

--- a/contrib/pyudmi/.gitignore
+++ b/contrib/pyudmi/.gitignore
@@ -1,0 +1,4 @@
+/build/
+/src/udmi/schema/
+/dist/
+/pyudmi.egg-info/

--- a/contrib/pyudmi/requirements.txt
+++ b/contrib/pyudmi/requirements.txt
@@ -1,0 +1,3 @@
+fastjsonschema
+pytz
+python-dateutil

--- a/contrib/pyudmi/setup.py
+++ b/contrib/pyudmi/setup.py
@@ -1,0 +1,32 @@
+from setuptools import setup, find_packages
+import shutil
+import os
+
+def iter_schema_files():
+    schema_dir = os.path.join("..", "..", "schema")
+    dst_dir = os.path.join("src", "udmi", "schema")
+    if os.path.exists(dst_dir):
+        shutil.rmtree(dst_dir)
+    os.makedirs(dst_dir)
+
+    for filename in os.listdir(schema_dir):
+        if filename.endswith("json"):
+            src = os.path.join(schema_dir, filename)
+            dst = os.path.join(dst_dir, filename)
+            shutil.copy(src, dst)
+            module_filepath = os.path.join("schema", filename)
+            yield(module_filepath)
+
+setup(
+    name='pyudmi',
+    version='0.0.5',
+    url='https://github.com/faucetsdn/udmi/contrib/pyudmi',
+    author='Paul Harter',
+    author_email='paul@glowinthedark.co.uk',
+    license="LICENSE",
+    description='Helper classes for working with udmi',
+    packages=find_packages('src'),
+    package_data={"udmi": [f for f in iter_schema_files()]},
+    package_dir={'udmi': 'src/udmi'},
+    install_requires=['pytz', 'fastjsonschema', 'python-dateutil']
+)

--- a/contrib/pyudmi/src/udmi/__init__.py
+++ b/contrib/pyudmi/src/udmi/__init__.py
@@ -1,0 +1,19 @@
+
+from .config import Config
+from .discover import Discover
+from .metadata import MetaData
+from .event_pointset import Pointset, EventPointset
+from .properties import Properties
+from .state import State
+
+__all__ = (
+    Config,
+    Discover,
+    MetaData,
+    Pointset,
+    EventPointset,
+    Properties,
+    State
+)
+
+

--- a/contrib/pyudmi/src/udmi/base.py
+++ b/contrib/pyudmi/src/udmi/base.py
@@ -1,0 +1,96 @@
+import json
+import os
+import pytz
+import datetime
+import fastjsonschema
+import udmi
+import dateutil.parser
+
+DEFAULT_UDMI_VERSION = 1
+
+VALIDATORS = {}
+PACKAGE_SCHEMATA_DIR = os.path.join(os.path.dirname(udmi.__file__), "schema")
+UDMI_SCHEMATA_DIR = os.path.join(os.path.dirname(udmi.__file__), "..", "..", "..", "..", "schema")
+
+SCHEMATA_DIR = PACKAGE_SCHEMATA_DIR if os.path.exists(PACKAGE_SCHEMATA_DIR) else UDMI_SCHEMATA_DIR
+
+
+def get_path(uri):
+    filename = os.path.basename(uri)
+    path = "%s/%s" % (SCHEMATA_DIR, filename)
+    with open(path, "r") as f:
+        return json.loads(f.read())
+
+
+def get_validator(name):
+    validator = VALIDATORS.get(name)
+    os.chdir(SCHEMATA_DIR)
+    if validator is None:
+        file_path = os.path.join(SCHEMATA_DIR, name)
+        with open(file_path, "r") as f:
+            schema = json.loads(f.read())
+        handlers = {"file": get_path}
+        validator = fastjsonschema.compile(schema, handlers=handlers)
+        VALIDATORS[name] = validator
+
+    return validator
+
+
+class UDMIBase:
+    schema = "none"
+
+    def __init__(self, version):
+        self.version = version
+        self.validate()
+
+    def __str__(self):
+        return json.dumps(self.as_dict(), indent=4, sort_keys=True)
+
+    def as_udmi(self):
+        return json.dumps(self.as_dict(), indent=4, sort_keys=True)
+
+    @classmethod
+    def from_string(cls, s):
+        return cls.from_dict(json.loads(s))
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(**d)
+
+    def as_dict(self):
+
+        d = {}
+
+        for name in self.__slots__:
+            value = getattr(self, name, None)
+            if value is not None:
+                if hasattr(value, "as_dict"):
+                    d[name] = value.as_dict()
+                elif type(value) in (str, int, float, list, dict, tuple, bool):
+                    d[name] = value
+                else:
+                    raise Exception("Can't serialise this value %s for json" % value)
+        return d
+
+    def validate(self):
+        validator = get_validator(self.schema)
+        validator(self.as_dict())
+
+
+    @staticmethod
+    def serialise_timestamp(timestamp):
+        if isinstance(timestamp, str):
+            dt = dateutil.parser.isoparse(timestamp)
+        elif isinstance(timestamp, datetime.datetime):
+            dt = timestamp
+        else:
+            raise Exception("Can't make sense of this timestamp %s" % timestamp)
+
+        utc = pytz.utc
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=utc)
+        else:
+            dt = dt.astimezone(utc)
+        as_iso = dt.isoformat("T") + "Z"
+        fixed = as_iso.replace("+00:00", "")
+        return fixed

--- a/contrib/pyudmi/src/udmi/base.py
+++ b/contrib/pyudmi/src/udmi/base.py
@@ -76,7 +76,6 @@ class UDMIBase:
         validator = get_validator(self.schema)
         validator(self.as_dict())
 
-
     @staticmethod
     def serialise_timestamp(timestamp):
         if isinstance(timestamp, str):

--- a/contrib/pyudmi/src/udmi/config.py
+++ b/contrib/pyudmi/src/udmi/config.py
@@ -1,46 +1,8 @@
-"""
-{
-  "title": "Device Config Schema",
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
-  "required": [
-    "timestamp",
-    "version"
-  ],
-  "properties": {
-    "timestamp": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "version": {
-      "enum": [
-        1
-      ]
-    },
-    "system": {
-      "$ref": "file:config_system.json#"
-    },
-    "gateway": {
-      "$ref": "file:config_gateway.json#"
-    },
-    "localnet": {
-      "$ref": "file:config_localnet.json#"
-    },
-    "pointset": {
-      "$ref": "file:config_pointset.json#"
-    }
-  }
-}
-
-"""
-
 from datetime import datetime
 from .base import UDMIBase, DEFAULT_UDMI_VERSION
 
 
 class Config(UDMIBase):
-
     schema = "config.json"
     __slots__ = ["version", "timestamp", "system", "pointset", "gateway"]
 
@@ -49,7 +11,6 @@ class Config(UDMIBase):
                  pointset: dict = None,
                  gateway: dict = None,
                  version=DEFAULT_UDMI_VERSION):
-
         self.timestamp = self.serialise_timestamp(timestamp)
         self.system = system
         self.pointset = pointset

--- a/contrib/pyudmi/src/udmi/config.py
+++ b/contrib/pyudmi/src/udmi/config.py
@@ -1,0 +1,57 @@
+"""
+{
+  "title": "Device Config Schema",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "required": [
+    "timestamp",
+    "version"
+  ],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "enum": [
+        1
+      ]
+    },
+    "system": {
+      "$ref": "file:config_system.json#"
+    },
+    "gateway": {
+      "$ref": "file:config_gateway.json#"
+    },
+    "localnet": {
+      "$ref": "file:config_localnet.json#"
+    },
+    "pointset": {
+      "$ref": "file:config_pointset.json#"
+    }
+  }
+}
+
+"""
+
+from datetime import datetime
+from .base import UDMIBase, DEFAULT_UDMI_VERSION
+
+
+class Config(UDMIBase):
+
+    schema = "config.json"
+    __slots__ = ["version", "timestamp", "system", "pointset", "gateway"]
+
+    def __init__(self, timestamp: (str, datetime),
+                 system: dict,
+                 pointset: dict = None,
+                 gateway: dict = None,
+                 version=DEFAULT_UDMI_VERSION):
+
+        self.timestamp = self.serialise_timestamp(timestamp)
+        self.system = system
+        self.pointset = pointset
+        self.gateway = gateway
+        super().__init__(version)

--- a/contrib/pyudmi/src/udmi/discover.py
+++ b/contrib/pyudmi/src/udmi/discover.py
@@ -1,70 +1,12 @@
-
-"""
-{
-  "title": "Device discover schema",
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
-  "properties": {
-    "timestamp": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "version": {
-      "enum": [
-        1
-      ]
-    },
-    "protocol": {
-      "type": "string"
-    },
-    "local_id": {
-      "type": "string"
-    },
-    "points": {
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z][a-z0-9]*(_[a-z0-9]+)*$": {
-          "$ref": "#/definitions/point_property_names"
-        }
-      }
-    }
-  },
-  "required": [
-    "timestamp",
-    "version",
-    "protocol",
-    "local_id",
-    "points"
-  ],
-  "definitions": {
-    "point_property_names": {
-      "propertyNames": {
-        "oneOf": [
-          {
-            "enum": [
-              "units",
-              "present_value"
-            ]
-          }
-        ]
-      }
-    }
-  }
-}
-
-"""
 from datetime import datetime
 from .base import UDMIBase, DEFAULT_UDMI_VERSION
 
 
 class Discover(UDMIBase):
-
     schema = "discover.json"
     __slots__ = ["version", "timestamp", "protocol", "local_id", "points"]
 
     def __init__(self, timestamp: datetime, protocol: str, local_id: str, points: dict, version=DEFAULT_UDMI_VERSION):
-
         self.timestamp = self.serialise_timestamp(timestamp)
         self.protocol = protocol
         self.local_id = local_id

--- a/contrib/pyudmi/src/udmi/discover.py
+++ b/contrib/pyudmi/src/udmi/discover.py
@@ -1,0 +1,72 @@
+
+"""
+{
+  "title": "Device discover schema",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "enum": [
+        1
+      ]
+    },
+    "protocol": {
+      "type": "string"
+    },
+    "local_id": {
+      "type": "string"
+    },
+    "points": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9]*(_[a-z0-9]+)*$": {
+          "$ref": "#/definitions/point_property_names"
+        }
+      }
+    }
+  },
+  "required": [
+    "timestamp",
+    "version",
+    "protocol",
+    "local_id",
+    "points"
+  ],
+  "definitions": {
+    "point_property_names": {
+      "propertyNames": {
+        "oneOf": [
+          {
+            "enum": [
+              "units",
+              "present_value"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+
+"""
+from datetime import datetime
+from .base import UDMIBase, DEFAULT_UDMI_VERSION
+
+
+class Discover(UDMIBase):
+
+    schema = "discover.json"
+    __slots__ = ["version", "timestamp", "protocol", "local_id", "points"]
+
+    def __init__(self, timestamp: datetime, protocol: str, local_id: str, points: dict, version=DEFAULT_UDMI_VERSION):
+
+        self.timestamp = self.serialise_timestamp(timestamp)
+        self.protocol = protocol
+        self.local_id = local_id
+        self.points = points
+        super().__init__(version)

--- a/contrib/pyudmi/src/udmi/envelope.py
+++ b/contrib/pyudmi/src/udmi/envelope.py
@@ -1,0 +1,65 @@
+"""
+{
+  "title": "Message envelope schema",
+  "additionalProperties": true,
+  "properties": {
+    "deviceId": {
+      "type": "string",
+      "pattern": "^[A-Z]{2,6}-[0-9]{1,6}$"
+    },
+    "deviceNumId": {
+      "type": "string",
+      "pattern": "^[0-9]+$"
+    },
+    "deviceRegistryId": {
+      "type": "string",
+      "pattern": "^[a-zA-Z][-a-zA-Z0-9._+~%]*[a-zA-Z0-9]$"
+    },
+    "projectId": {
+      "type": "string",
+      "pattern": "^([.a-z]+:)?[a-z][-a-z0-9]*[a-z0-9]$"
+    },
+    "subFolder": {
+      "enum": [
+        "config",
+        "discover",
+        "system",
+        "metadata",
+        "pointset",
+        "state"
+      ]
+    }
+  },
+  "required": [
+    "projectId",
+    "deviceRegistryId",
+    "deviceNumId",
+    "deviceId",
+    "subFolder"
+  ]
+}
+
+"""
+
+from .base import UDMIBase, DEFAULT_UDMI_VERSION
+
+
+class Envelope(UDMIBase):
+
+    schema = "envelope.json"
+    __slots__ = [
+        "projectId",
+        "deviceRegistryId",
+        "deviceNumId",
+        "deviceId",
+        "subFolder"
+    ]
+
+    def __init__(self, projectId, deviceRegistryId, deviceNumId, deviceId, subFolder, version=None):
+
+        self.projectId = projectId
+        self.deviceRegistryId = deviceRegistryId
+        self.deviceNumId = deviceNumId
+        self.deviceId = deviceId
+        self.subFolder = subFolder
+        super().__init__(version)

--- a/contrib/pyudmi/src/udmi/envelope.py
+++ b/contrib/pyudmi/src/udmi/envelope.py
@@ -1,51 +1,7 @@
-"""
-{
-  "title": "Message envelope schema",
-  "additionalProperties": true,
-  "properties": {
-    "deviceId": {
-      "type": "string",
-      "pattern": "^[A-Z]{2,6}-[0-9]{1,6}$"
-    },
-    "deviceNumId": {
-      "type": "string",
-      "pattern": "^[0-9]+$"
-    },
-    "deviceRegistryId": {
-      "type": "string",
-      "pattern": "^[a-zA-Z][-a-zA-Z0-9._+~%]*[a-zA-Z0-9]$"
-    },
-    "projectId": {
-      "type": "string",
-      "pattern": "^([.a-z]+:)?[a-z][-a-z0-9]*[a-z0-9]$"
-    },
-    "subFolder": {
-      "enum": [
-        "config",
-        "discover",
-        "system",
-        "metadata",
-        "pointset",
-        "state"
-      ]
-    }
-  },
-  "required": [
-    "projectId",
-    "deviceRegistryId",
-    "deviceNumId",
-    "deviceId",
-    "subFolder"
-  ]
-}
-
-"""
-
 from .base import UDMIBase, DEFAULT_UDMI_VERSION
 
 
 class Envelope(UDMIBase):
-
     schema = "envelope.json"
     __slots__ = [
         "projectId",
@@ -56,7 +12,6 @@ class Envelope(UDMIBase):
     ]
 
     def __init__(self, projectId, deviceRegistryId, deviceNumId, deviceId, subFolder, version=None):
-
         self.projectId = projectId
         self.deviceRegistryId = deviceRegistryId
         self.deviceNumId = deviceNumId

--- a/contrib/pyudmi/src/udmi/event_pointset.py
+++ b/contrib/pyudmi/src/udmi/event_pointset.py
@@ -1,69 +1,14 @@
-"""
-{
-  "title": "Pointset telemetry schema",
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
-  "properties": {
-    "etag": {
-      "type": "string"
-    },
-    "timestamp": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "version": {
-      "enum": [
-        1
-      ]
-    },
-    "points": {
-      "additionalProperties": false,
-      "patternProperties": {
-        "^[a-z][a-z0-9]*(_[a-z0-9]+)*$": {
-          "$ref": "#/definitions/point_property_names"
-        }
-      }
-    }
-  },
-  "required": [
-    "timestamp",
-    "version",
-    "points"
-  ],
-  "definitions": {
-    "point_property_names": {
-      "type": "object",
-      "propertyNames": {
-        "oneOf": [
-          {
-            "enum": [
-              "present_value"
-            ]
-          }
-        ]
-      },
-      "required": [
-        "present_value"
-      ]
-    }
-  }
-}
-
-"""
-
 from .base import UDMIBase, DEFAULT_UDMI_VERSION
 
 
 class EventPointset(UDMIBase):
-
     schema = "event_pointset.json"
     __slots__ = ["version", "timestamp", "points"]
 
     def __init__(self, timestamp, points, version=DEFAULT_UDMI_VERSION):
-
         self.timestamp = self.serialise_timestamp(timestamp)
         self.points = points
         super().__init__(version)
+
 
 Pointset = EventPointset

--- a/contrib/pyudmi/src/udmi/event_pointset.py
+++ b/contrib/pyudmi/src/udmi/event_pointset.py
@@ -1,0 +1,69 @@
+"""
+{
+  "title": "Pointset telemetry schema",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "etag": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "enum": [
+        1
+      ]
+    },
+    "points": {
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-z][a-z0-9]*(_[a-z0-9]+)*$": {
+          "$ref": "#/definitions/point_property_names"
+        }
+      }
+    }
+  },
+  "required": [
+    "timestamp",
+    "version",
+    "points"
+  ],
+  "definitions": {
+    "point_property_names": {
+      "type": "object",
+      "propertyNames": {
+        "oneOf": [
+          {
+            "enum": [
+              "present_value"
+            ]
+          }
+        ]
+      },
+      "required": [
+        "present_value"
+      ]
+    }
+  }
+}
+
+"""
+
+from .base import UDMIBase, DEFAULT_UDMI_VERSION
+
+
+class EventPointset(UDMIBase):
+
+    schema = "event_pointset.json"
+    __slots__ = ["version", "timestamp", "points"]
+
+    def __init__(self, timestamp, points, version=DEFAULT_UDMI_VERSION):
+
+        self.timestamp = self.serialise_timestamp(timestamp)
+        self.points = points
+        super().__init__(version)
+
+Pointset = EventPointset

--- a/contrib/pyudmi/src/udmi/event_system.py
+++ b/contrib/pyudmi/src/udmi/event_system.py
@@ -1,43 +1,12 @@
-"""
-{
-  "title": "System event schema",
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
-  "properties": {
-    "timestamp": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "version": {
-      "enum": [
-        1
-      ]
-    },
-    "logentries": {
-      "type": "array",
-      "items": {
-        "$ref": "file:common.json#/definitions/entry"
-      }
-    }
-  },
-  "required": [
-    "timestamp",
-    "version"
-  ]
-}
-"""
 import copy
 from .base import UDMIBase, DEFAULT_UDMI_VERSION
 
 
 class EventSystem(UDMIBase):
-
     schema = "event_system.json"
     __slots__ = ["version", "timestamp", "logentries"]
 
     def __init__(self, timestamp, logentries, version=DEFAULT_UDMI_VERSION):
-
         self.timestamp = self.serialise_timestamp(timestamp)
 
         def munge_timestamp(l):

--- a/contrib/pyudmi/src/udmi/event_system.py
+++ b/contrib/pyudmi/src/udmi/event_system.py
@@ -1,0 +1,49 @@
+"""
+{
+  "title": "System event schema",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "enum": [
+        1
+      ]
+    },
+    "logentries": {
+      "type": "array",
+      "items": {
+        "$ref": "file:common.json#/definitions/entry"
+      }
+    }
+  },
+  "required": [
+    "timestamp",
+    "version"
+  ]
+}
+"""
+import copy
+from .base import UDMIBase, DEFAULT_UDMI_VERSION
+
+
+class EventSystem(UDMIBase):
+
+    schema = "event_system.json"
+    __slots__ = ["version", "timestamp", "logentries"]
+
+    def __init__(self, timestamp, logentries, version=DEFAULT_UDMI_VERSION):
+
+        self.timestamp = self.serialise_timestamp(timestamp)
+
+        def munge_timestamp(l):
+            with_timestamp = copy.deepcopy(l)
+            with_timestamp["timestamp"] = self.serialise_timestamp(with_timestamp["timestamp"])
+            return with_timestamp
+
+        self.logentries = [munge_timestamp(l) for l in logentries]
+        super().__init__(version)

--- a/contrib/pyudmi/src/udmi/metadata.py
+++ b/contrib/pyudmi/src/udmi/metadata.py
@@ -1,60 +1,11 @@
-
-"""
-{
-  "title": "Device metadata schema",
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
-  "required": [
-    "timestamp",
-    "version",
-    "system"
-  ],
-  "properties": {
-    "timestamp": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "version": {
-      "enum": [
-        1
-      ]
-    },
-    "hash": {
-      "type": "string",
-      "pattern": "^[0-9a-z]{8}$"
-    },
-    "cloud": {
-      "$ref": "file:metadata_cloud.json#"
-    },
-    "system": {
-      "$ref": "file:metadata_system.json#"
-    },
-    "gateway": {
-      "$ref": "file:metadata_gateway.json#"
-    },
-    "localnet": {
-      "$ref": "file:metadata_localnet.json#"
-    },
-    "pointset": {
-      "$ref": "file:metadata_pointset.json#"
-    }
-  }
-}
-
-"""
-
-
 from .base import UDMIBase, DEFAULT_UDMI_VERSION
 
 
 class MetaData(UDMIBase):
-
     schema = "metadata.json"
     __slots__ = ["version", "timestamp", "system", "hash", "gateway", "pointset"]
 
     def __init__(self, timestamp, system, hash=None, gateway=None, pointset=None, version=DEFAULT_UDMI_VERSION):
-
         self.timestamp = self.serialise_timestamp(timestamp)
         self.pointset = pointset
         self.gateway = gateway

--- a/contrib/pyudmi/src/udmi/metadata.py
+++ b/contrib/pyudmi/src/udmi/metadata.py
@@ -1,0 +1,63 @@
+
+"""
+{
+  "title": "Device metadata schema",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "required": [
+    "timestamp",
+    "version",
+    "system"
+  ],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "enum": [
+        1
+      ]
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^[0-9a-z]{8}$"
+    },
+    "cloud": {
+      "$ref": "file:metadata_cloud.json#"
+    },
+    "system": {
+      "$ref": "file:metadata_system.json#"
+    },
+    "gateway": {
+      "$ref": "file:metadata_gateway.json#"
+    },
+    "localnet": {
+      "$ref": "file:metadata_localnet.json#"
+    },
+    "pointset": {
+      "$ref": "file:metadata_pointset.json#"
+    }
+  }
+}
+
+"""
+
+
+from .base import UDMIBase, DEFAULT_UDMI_VERSION
+
+
+class MetaData(UDMIBase):
+
+    schema = "metadata.json"
+    __slots__ = ["version", "timestamp", "system", "hash", "gateway", "pointset"]
+
+    def __init__(self, timestamp, system, hash=None, gateway=None, pointset=None, version=DEFAULT_UDMI_VERSION):
+
+        self.timestamp = self.serialise_timestamp(timestamp)
+        self.pointset = pointset
+        self.gateway = gateway
+        self.system = system
+        self.hash = hash
+        super().__init__(version)

--- a/contrib/pyudmi/src/udmi/properties.py
+++ b/contrib/pyudmi/src/udmi/properties.py
@@ -1,46 +1,11 @@
-"""
-{
-  "title": "Device Properties Schema",
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
-  "required": [
-    "key_type",
-    "version",
-    "connect"
-  ],
-  "properties": {
-    "key_type": {
-      "enum": [
-        "RSA_PEM",
-        "RSA_X509_PEM"
-      ]
-    },
-    "version": {
-      "enum": [
-        1
-      ]
-    },
-    "connect": {
-      "enum": [
-        "direct"
-      ]
-    }
-  }
-}
-
-"""
-
 from .base import UDMIBase, DEFAULT_UDMI_VERSION
 
 
 class Properties(UDMIBase):
-
     schema = "properties.json"
     __slots__ = ["version", "key_type", "connect"]
 
     def __init__(self, key_type, connect, version=DEFAULT_UDMI_VERSION):
-
         self.key_type = key_type
         self.connect = connect
         super().__init__(version)

--- a/contrib/pyudmi/src/udmi/properties.py
+++ b/contrib/pyudmi/src/udmi/properties.py
@@ -1,0 +1,46 @@
+"""
+{
+  "title": "Device Properties Schema",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "required": [
+    "key_type",
+    "version",
+    "connect"
+  ],
+  "properties": {
+    "key_type": {
+      "enum": [
+        "RSA_PEM",
+        "RSA_X509_PEM"
+      ]
+    },
+    "version": {
+      "enum": [
+        1
+      ]
+    },
+    "connect": {
+      "enum": [
+        "direct"
+      ]
+    }
+  }
+}
+
+"""
+
+from .base import UDMIBase, DEFAULT_UDMI_VERSION
+
+
+class Properties(UDMIBase):
+
+    schema = "properties.json"
+    __slots__ = ["version", "key_type", "connect"]
+
+    def __init__(self, key_type, connect, version=DEFAULT_UDMI_VERSION):
+
+        self.key_type = key_type
+        self.connect = connect
+        super().__init__(version)

--- a/contrib/pyudmi/src/udmi/state.py
+++ b/contrib/pyudmi/src/udmi/state.py
@@ -1,0 +1,46 @@
+
+"""
+{
+  "title": "Device State schema",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "required": [
+    "timestamp",
+    "version",
+    "system"
+  ],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "version": {
+      "enum": [
+        1
+      ]
+    },
+    "system": {
+      "$ref": "file:state_system.json#"
+    },
+    "pointset": {
+      "$ref": "file:state_pointset.json#"
+    }
+  }
+}
+"""
+
+from .base import UDMIBase, DEFAULT_UDMI_VERSION
+
+
+class State(UDMIBase):
+
+    schema = "state.json"
+    __slots__ = ["version", "system", "timestamp", "pointset"]
+
+    def __init__(self, timestamp, system, pointset=None, version=DEFAULT_UDMI_VERSION):
+
+        self.timestamp = self.serialise_timestamp(timestamp)
+        self.system = system
+        self.pointset = pointset
+        super().__init__(version)

--- a/contrib/pyudmi/src/udmi/state.py
+++ b/contrib/pyudmi/src/udmi/state.py
@@ -1,45 +1,11 @@
-
-"""
-{
-  "title": "Device State schema",
-  "type": "object",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "additionalProperties": false,
-  "required": [
-    "timestamp",
-    "version",
-    "system"
-  ],
-  "properties": {
-    "timestamp": {
-      "type": "string",
-      "format": "date-time"
-    },
-    "version": {
-      "enum": [
-        1
-      ]
-    },
-    "system": {
-      "$ref": "file:state_system.json#"
-    },
-    "pointset": {
-      "$ref": "file:state_pointset.json#"
-    }
-  }
-}
-"""
-
 from .base import UDMIBase, DEFAULT_UDMI_VERSION
 
 
 class State(UDMIBase):
-
     schema = "state.json"
     __slots__ = ["version", "system", "timestamp", "pointset"]
 
     def __init__(self, timestamp, system, pointset=None, version=DEFAULT_UDMI_VERSION):
-
         self.timestamp = self.serialise_timestamp(timestamp)
         self.system = system
         self.pointset = pointset

--- a/contrib/pyudmi/src/udmi/tests/test_udmi_schemata.py
+++ b/contrib/pyudmi/src/udmi/tests/test_udmi_schemata.py
@@ -1,0 +1,178 @@
+import unittest
+import datetime
+import os
+from fastjsonschema import JsonSchemaException
+
+from udmi.base import SCHEMATA_DIR
+from udmi.config import Config
+from udmi.discover import Discover
+from udmi.metadata import MetaData
+from udmi.event_pointset import Pointset, EventPointset
+from udmi.event_system import EventSystem
+from udmi.envelope import Envelope
+from udmi.properties import Properties
+from udmi.state import State
+
+os.chdir(SCHEMATA_DIR)
+
+class TestCreateTopLevelObjects(unittest.TestCase):
+
+    def test_create_config(self):
+        timestamp = datetime.datetime.utcnow()
+        system = {
+            "min_loglevel": 500
+        }
+        gateway = {
+            "proxy_ids": ["AGH-725", "HAT-6"]
+        }
+        pointset = {
+            "sample_limit_sec": 2,
+            "sample_rate_sec": 500,
+            "points": {
+                "return_air_temperature_sensor": {
+                    "set_value": 21.1
+                }
+            }
+        }
+
+        config1 = Config(timestamp, system, pointset, gateway)
+        # check without the optional bits
+        _ = Config(timestamp, system)
+        # try round trip
+        udmi = str(config1)
+        remade = Config.from_string(udmi)
+        self.assertEqual(config1.as_dict(), remade.as_dict())
+
+    def test_create_discover(self):
+        timestamp = datetime.datetime.utcnow()
+        protocol = "bacnet"
+        local_id = "92EA09"
+        points = {
+            "reading_value": {
+                "units": "C",
+                "present_value": 21.30108642578125
+            }
+        }
+
+        discover = Discover(timestamp, protocol, local_id, points)
+
+        # try round trip
+        udmi = str(discover)
+        remade = Discover.from_string(udmi)
+        self.assertEqual(discover.as_dict(), remade.as_dict())
+
+
+    def test_create_metadata(self):
+        timestamp = datetime.datetime.utcnow()
+        system = {
+            "location": {
+                "site": "US-SFO-XYY",
+                "section": "NW-2F",
+                "position": {
+                    "x": 10,
+                    "y": 20
+                }
+            },
+            "physical_tag": {
+                "asset": {
+                    "guid": "bim://04aEp5ymD_$u5IxhJN2aGi",
+                    "name": "USSFO-234567"
+                }
+            }
+        }
+        hash = "12345678"
+        gateway = {
+            "gateway_id": "GAT-12"
+        }
+
+        pointset = {
+            "points": {
+                "return_air_temperature_sensor": {
+                    "units": "Degrees-Celsius"
+                }
+            }
+        }
+
+        meta_data = MetaData(timestamp, system, hash=hash, gateway=gateway, pointset=pointset)
+
+        # try round trip
+        udmi = str(meta_data)
+        remade = MetaData.from_string(udmi)
+        self.assertEqual(meta_data.as_dict(), remade.as_dict())
+        _meta_data = MetaData(timestamp, system)
+
+
+    def test_create_pointset(self):
+        timestamp = datetime.datetime.utcnow()
+        points = {
+            "reading_value": {
+                "present_value": 21.30108642578125
+            },
+            "yoyo_motion_sensor": {
+                "present_value": True
+            },
+            "enum_value": {
+                "present_value": "hello"
+            }
+        }
+
+        pointset = EventPointset(timestamp, points)
+        # try round trip
+        udmi = str(pointset)
+        remade = Pointset.from_string(udmi)
+        self.assertEqual(pointset.as_dict(), remade.as_dict())
+        self.assertRaises(JsonSchemaException, Pointset, timestamp, None)
+
+
+    def test_create_system_event(self):
+        timestamp = datetime.datetime.utcnow()
+        logentries = [{
+            "message": "hello",
+            "category": "one.two.three",
+            "timestamp": timestamp,
+            "level": 200
+        }]
+
+        event_system = EventSystem(timestamp, logentries)
+        # try round trip
+        udmi = str(event_system)
+        remade = EventSystem.from_string(udmi)
+        self.assertEqual(event_system.as_dict(), remade.as_dict())
+
+
+    def test_create_envelope(self):
+        envelope = Envelope("projectprojectid", "device_reg_id", "45", "GHB-001", "pointset")
+        # try round trip
+        udmi = str(envelope)
+        remade = Envelope.from_string(udmi)
+        self.assertEqual(envelope.as_dict(), remade.as_dict())
+
+    def test_create_properties(self):
+
+        key_type = "RSA_PEM"
+        connect = "direct"
+
+        properties = Properties(key_type, connect)
+
+        # try round trip
+        udmi = str(properties)
+        remade = Properties.from_string(udmi)
+        self.assertEqual(properties.as_dict(), remade.as_dict())
+
+    def test_create_state(self):
+        timestamp = datetime.datetime.utcnow()
+        system = {
+            "make_model": "ACME Bird Trap",
+            "firmware": {
+                "version": "3.2a"
+            },
+            "operational": True,
+            "serial_no": "1234567890"
+        }
+
+        state = State(timestamp, system, pointset=None)
+
+        # try round trip
+        udmi = str(state)
+        remade = State.from_string(udmi)
+        self.assertEqual(state.as_dict(), remade.as_dict())

--- a/schema/metadata_system.json
+++ b/schema/metadata_system.json
@@ -47,7 +47,7 @@
           "properties": {
             "guid": {
               "type": "string",
-              "pattern": "^[a-z]+://[-0-9a-zA-Z_$]+$"
+              "pattern": "^[a-z]+://[-0-9a-zA-Z_\\$]+$"
             },
             "site": {
               "type": "string",


### PR DESCRIPTION
This is an updated version of pyudmi that correctly uses the latest json schemas.

There is one quirk: I am using a library called fastjsonschema which needs to have `$` always escaped in regex. See docs here.

https://horejsek.github.io/python-fastjsonschema/

So I have escaped a `$` in the `metadata_system.json` which should have no adverse effects.
