### PR TITLE
Bugfix for x509 device registration

### DIFF
--- a/pubber/src/main/java/daq/pubber/MqttPublisher.java
+++ b/pubber/src/main/java/daq/pubber/MqttPublisher.java
@@ -346,10 +346,10 @@ public class MqttPublisher {
             .setExpiration(now.plusMinutes(60).toDate())
             .setAudience(projectId);
 
-    if (algorithm.equals("RS256")) {
+    if (algorithm.equals("RS256") || algorithm.equals("RS256_X509")) {
       PrivateKey privateKey = loadKeyBytes(privateKeyBytes, "RSA");
       return jwtBuilder.signWith(SignatureAlgorithm.RS256, privateKey).compact();
-    } else if (algorithm.equals("ES256")) {
+    } else if (algorithm.equals("ES256") || algorithm.equals("ES256_X509")) {
       PrivateKey privateKey = loadKeyBytes(privateKeyBytes, "EC");
       return jwtBuilder.signWith(SignatureAlgorithm.ES256, privateKey).compact();
     } else {

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
@@ -104,6 +104,7 @@ class LocalDevice {
       ES_AUTH_TYPE, ES_PRIVATE_KEY_FILES,
       ES_CERT_TYPE, ES_PRIVATE_KEY_FILES
   );
+
   private static final Map<String, String> PUBLIC_KEY_FILE_MAP = ImmutableMap.of(
       RSA_AUTH_TYPE, RSA_PUBLIC_PEM,
       RSA_CERT_TYPE, RSA_CERT_PEM,
@@ -112,11 +113,16 @@ class LocalDevice {
   );
 
   private static final Set<String> OPTIONAL_FILES = ImmutableSet.of(
-      RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM,
+      RSA_PUBLIC_PEM, RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM, 
+      ES_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM,
       GENERATED_CONFIG_JSON, DEVICE_ERRORS_JSON, NORMALIZED_JSON, SAMPLES_DIR);
   private static final Set<String> ALL_KEY_FILES = ImmutableSet.of(
       RSA_CERT_PEM, RSA_PUBLIC_PEM, RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM,
       ES_CERT_PEM, ES_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM
+  );
+  private static final Set<String> ALL_CERT_FILES = ImmutableSet.of(
+      RSA_CERT_PEM, 
+      ES_CERT_PEM
   );
 
   private static final Map<String, String> AUTH_TYPE_MAP = ImmutableMap.of(
@@ -270,7 +276,15 @@ class LocalDevice {
       if (!hasAuthType()) {
         throw new RuntimeException("Credential cloud.auth_type definition missing");
       }
-      for (String keyFile : ALL_KEY_FILES) {
+      String authType = getAuthType();
+      Set<String> keyFiles;
+      if (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE))
+      {
+        keyFiles = ALL_CERT_FILES;
+      } else {
+        keyFiles = ALL_KEY_FILES;
+      }
+      for (String keyFile : keyFiles) {
         DeviceCredential deviceCredential = getDeviceCredential(keyFile);
         if (deviceCredential != null) {
           deviceCredentials.add(deviceCredential);

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
@@ -311,10 +311,9 @@ class LocalDevice {
     Set<String> certFile = getCertFiles();
     Set<String> publicKeyFile = Set.of(getPublicKeyFile());
     Set<String> privateKeyFiles = getPrivateKeyFiles();
-    Set<String> rtn = (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE)) ? 
+    return (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE)) ? 
         Sets.union(Sets.union(publicKeyFile, certFile), privateKeyFiles) : 
         Sets.union(publicKeyFile, privateKeyFiles);
-    return rtn;
   }
 
   private Set<String> getPrivateKeyFiles() {

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
@@ -111,24 +111,21 @@ class LocalDevice {
       ES_CERT_TYPE, ES_PUBLIC_PEM
   );
   private static final Map<String, String> CERT_FILE_MAP = ImmutableMap.of(
-    RSA_CERT_TYPE, RSA_CERT_PEM,
-    ES_CERT_TYPE, ES_CERT_PEM
+      RSA_CERT_TYPE, RSA_CERT_PEM,
+      ES_CERT_TYPE, ES_CERT_PEM
   );
   private static final Set<String> OPTIONAL_FILES = ImmutableSet.of(
-    RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM,
-    GENERATED_CONFIG_JSON, DEVICE_ERRORS_JSON, NORMALIZED_JSON, SAMPLES_DIR
+      RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM,
+      GENERATED_CONFIG_JSON, DEVICE_ERRORS_JSON, NORMALIZED_JSON, SAMPLES_DIR
   );
-
   private static final Set<String> ALL_KEY_FILES = ImmutableSet.of(
-      RSA_CERT_PEM, RSA_PUBLIC_PEM, RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM,
-      ES_CERT_PEM, ES_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM
+      RSA_PUBLIC_PEM, RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM,
+      ES_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM
   );
-
   private static final Set<String> ALL_CERT_FILES = ImmutableSet.of(
       RSA_CERT_PEM,
       ES_CERT_PEM
   );
-
   private static final Map<String, String> AUTH_TYPE_MAP = ImmutableMap.of(
       RSA_AUTH_TYPE, RSA_KEY_FORMAT,
       RSA_CERT_TYPE, RSA_CERT_FORMAT,
@@ -311,28 +308,35 @@ class LocalDevice {
       return ImmutableSet.of();
     }
     String authType = getAuthType();
-    Set<String> certFile = (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE)) ? Set.of(certFile()) : null;
-    Set<String> publicKeyFile = Set.of(publicKeyFile());
-    Set<String> privateKeyFiles = privateKeyFiles();
+    Set<String> certFile = getCertFiles();
+    Set<String> publicKeyFile = Set.of(getPublicKeyFile());
+    Set<String> privateKeyFiles = getPrivateKeyFiles();
     Set<String> rtn = (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE)) ? 
-       Sets.union(Sets.union(publicKeyFile, certFile), privateKeyFiles) : 
-       Sets.union(publicKeyFile, privateKeyFiles);
+        Sets.union(Sets.union(publicKeyFile, certFile), privateKeyFiles) : 
+        Sets.union(publicKeyFile, privateKeyFiles);
     return rtn;
   }
 
-  private Set<String> privateKeyFiles() {
+  private Set<String> getPrivateKeyFiles() {
     if (isDeviceKeySource() || !hasAuthType()) {
       return Set.of();
     }
     return PRIVATE_KEY_FILES_MAP.get(getAuthType());
   }
 
-  private String publicKeyFile() {
+  private String getPublicKeyFile() {
+    if (isDeviceKeySource() || !hasAuthType()) {
+      return null;
+    }
     return PUBLIC_KEY_FILE_MAP.get(getAuthType());
   }
 
-  private String certFile() {
-    return CERT_FILE_MAP.get(getAuthType());
+  private Set<String> getCertFiles() {
+    if (isDeviceKeySource() || !hasAuthType()) {
+      return Set.of();
+    }
+    String authType = getAuthType();
+    return (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE)) ?  Set.of(CERT_FILE_MAP.get(getAuthType())) : Set.of();
   }
 
   boolean isGateway() {

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
@@ -104,24 +104,28 @@ class LocalDevice {
       ES_AUTH_TYPE, ES_PRIVATE_KEY_FILES,
       ES_CERT_TYPE, ES_PRIVATE_KEY_FILES
   );
-
   private static final Map<String, String> PUBLIC_KEY_FILE_MAP = ImmutableMap.of(
       RSA_AUTH_TYPE, RSA_PUBLIC_PEM,
-      RSA_CERT_TYPE, RSA_CERT_PEM,
+      RSA_CERT_TYPE, RSA_PUBLIC_PEM,
       ES_AUTH_TYPE, ES_PUBLIC_PEM,
-      ES_CERT_TYPE, ES_CERT_PEM
+      ES_CERT_TYPE, ES_PUBLIC_PEM
+  );
+  private static final Map<String, String> CERT_FILE_MAP = ImmutableMap.of(
+    RSA_CERT_TYPE, RSA_CERT_PEM,
+    ES_CERT_TYPE, ES_CERT_PEM
+  );
+  private static final Set<String> OPTIONAL_FILES = ImmutableSet.of(
+    RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM,
+    GENERATED_CONFIG_JSON, DEVICE_ERRORS_JSON, NORMALIZED_JSON, SAMPLES_DIR
   );
 
-  private static final Set<String> OPTIONAL_FILES = ImmutableSet.of(
-      RSA_PUBLIC_PEM, RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM, 
-      ES_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM,
-      GENERATED_CONFIG_JSON, DEVICE_ERRORS_JSON, NORMALIZED_JSON, SAMPLES_DIR);
   private static final Set<String> ALL_KEY_FILES = ImmutableSet.of(
       RSA_CERT_PEM, RSA_PUBLIC_PEM, RSA2_PUBLIC_PEM, RSA3_PUBLIC_PEM,
       ES_CERT_PEM, ES_PUBLIC_PEM, ES2_PUBLIC_PEM, ES3_PUBLIC_PEM
   );
+
   private static final Set<String> ALL_CERT_FILES = ImmutableSet.of(
-      RSA_CERT_PEM, 
+      RSA_CERT_PEM,
       ES_CERT_PEM
   );
 
@@ -277,13 +281,7 @@ class LocalDevice {
         throw new RuntimeException("Credential cloud.auth_type definition missing");
       }
       String authType = getAuthType();
-      Set<String> keyFiles;
-      if (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE))
-      {
-        keyFiles = ALL_CERT_FILES;
-      } else {
-        keyFiles = ALL_KEY_FILES;
-      }
+      Set<String> keyFiles = (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE)) ? ALL_CERT_FILES : ALL_KEY_FILES;
       for (String keyFile : keyFiles) {
         DeviceCredential deviceCredential = getDeviceCredential(keyFile);
         if (deviceCredential != null) {
@@ -309,12 +307,17 @@ class LocalDevice {
   }
 
   private Set<String> keyFiles() {
-    if (!isDirectConnect()) {
+    if (!isDirectConnect() || !hasAuthType()) {
       return ImmutableSet.of();
     }
+    String authType = getAuthType();
+    Set<String> certFile = (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE)) ? Set.of(certFile()) : null;
     Set<String> publicKeyFile = Set.of(publicKeyFile());
     Set<String> privateKeyFiles = privateKeyFiles();
-    return Sets.union(publicKeyFile, privateKeyFiles);
+    Set<String> rtn = (authType.equals(ES_CERT_TYPE) || authType.equals(RSA_CERT_TYPE)) ? 
+       Sets.union(Sets.union(publicKeyFile, certFile), privateKeyFiles) : 
+       Sets.union(publicKeyFile, privateKeyFiles);
+    return rtn;
   }
 
   private Set<String> privateKeyFiles() {
@@ -326,6 +329,10 @@ class LocalDevice {
 
   private String publicKeyFile() {
     return PUBLIC_KEY_FILE_MAP.get(getAuthType());
+  }
+
+  private String certFile() {
+    return CERT_FILE_MAP.get(getAuthType());
   }
 
   boolean isGateway() {


### PR DESCRIPTION
I've discovered a bug with the x509 device registration that prevents the registration of devices if RSA and ES public keys are contained together with X509 certificates in the device folder.
This bugfix corrects this behaviour and allows all devices to be registered without having to manually remove public keys from the device folder when the creation of a key with a self-signed X509 certificate is selected.