### PR TITLE
CI UI Tests - Update NodeJS to v16

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2.3.4
       - uses: actions/setup-node@v2
         with:
-          node-version: '15'
+          node-version: '16'
       - name: Install Chrome
         run: |
           # Sometimes the unstable version is desirable to match versions with ChromeDriver


### PR DESCRIPTION
Updates NodeJS to v16 to fix issue with CI tests

```
Node.js version v15.14.0 detected.
5
The Angular CLI requires a minimum Node.js version of either v12.20, v14.15, or v16.10.
```