### PR TITLE
Adding source message field

### DIFF
--- a/schema/event_pointset.json
+++ b/schema/event_pointset.json
@@ -17,6 +17,9 @@
       "minimum": 1,
       "maximum": 1
     },
+    "source": {
+      "type": "string"
+    },
     "partial_update": {
       "description": "Indicates if this is a partial update (only some points may be included)",
       "type": "boolean"

--- a/tests/event_pointset.tests/envelope.json
+++ b/tests/event_pointset.tests/envelope.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "timestamp": "2018-08-26T21:39:29.364Z",
+  "source": "ZZ-TRI-FECTA/AHU-32",
+  "points": {
+    "reading_value": {
+      "present_value": 21.30108642578125
+    },
+    "nexus_sensor": {
+      "present_value": 21.1
+    },
+    "yoyo_motion_sensor": {
+      "present_value": true
+    },
+    "enum_value": {
+      "present_value": "hello"
+    }
+  }
+}


### PR DESCRIPTION
Example of a simple "source" field for messages to indicate where the message came from (implementation dependent info).