### PR TITLE
Predefined status/log entries

### DIFF
--- a/docs/messages/status.md
+++ b/docs/messages/status.md
@@ -24,3 +24,17 @@ different than the top-level `timestamp` field (which is when the log was sent).
 * The status `level` should conform to the numerical
 [Stackdriver LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity)
 levels. The `DEFAULT` value of 0 is not allowed (lowest value is 100, maximum 800).
+
+
+## Log Severity Levels
+
+| Level | Label | Description |
+|---|---|---|
+| 100 | DEBUG | Debug or trace information. |
+| 200 | INFO | Routine information, such as ongoing status or performance. |
+| 300 | NOTICE | Normal but significant events, such as start up, shut down, or a configuration change. |
+| 400 | WARNING | Warning events might cause problems. |
+| 500 | ERROR | Error events are likely to cause problems. |
+| 600 | CRITICAL | Critical events cause more severe problems or outages. |
+| 700 | ALERT | A person must take an action immediately. |
+| 800 | EMERGENCY | One or more systems are unusable. |

--- a/docs/specs/logging.md
+++ b/docs/specs/logging.md
@@ -1,0 +1,13 @@
+# Logging
+
+## Status Categories
+
+This document defines some of the minimum predefined status categories for system log messages or status entries
+
+Other statuses and log entries with not described below can (and should) be published
+
+| Category | Scope | Loglevel |Description |
+|---|---|---|---|
+| `state.pointset.points.config.failure` | state.pointset.point | 600 | When a writeback failed to apply
+| `state.pointset.points.config.invalid` | state.pointset.point, state.pointset | 600 | When a writeback is invalid (e.g. set_value, etag, expiry, )|
+| `event.system.startup` | event.system | 200 | When the system has started |

--- a/docs/specs/logging.md
+++ b/docs/specs/logging.md
@@ -2,12 +2,16 @@
 
 ## Status Categories
 
-This document defines some of the minimum predefined status categories for system log messages or status entries
+This document defines some of the minimum predefined status categories for
+system log messages or status entries. 
 
-Other statuses and log entries with not described below can (and should) be published
+Other statuses and log entries with not described below can (and should) be
+published. Additionally, other log/status entries related to these (such as
+exceptions) should be published.
 
 | Category | Scope | Loglevel |Description |
 |---|---|---|---|
 | `state.pointset.points.config.failure` | state.pointset.point | 600 | When a writeback failed to apply
 | `state.pointset.points.config.invalid` | state.pointset.point, state.pointset | 600 | When a writeback is invalid (e.g. set_value, etag, expiry, )|
-| `event.system.startup` | event.system | 200 | When the system has started |
+| `event.system.startup` | event.system | 300 | When the system has started |
+| `event.system.gateway.attach` | event.system | 600 | Error gateway attaching to proxy device |


### PR DESCRIPTION
Published as a draft for now for discussion and to build on.

I think there is a need to have a list of predefined system status logs/log entries. Already in UDMI, there are some are defined (for write back), but there's benefit in consolidating these into one file as a reference, and to add additional information such as log levels.

Additionally, we're now asking device manufacturers to send out some logs (e.g. a system start up log entry) but we are not defining the details of this. 

Without doing so, different devices may represent the same issues/logs/status differently

This attempts to consolidate the log entries and define the minimum log entries needed