### PR TITLE
If device names are supplied on argv, process only these devices

### DIFF
--- a/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
@@ -516,14 +516,14 @@ public class Registrar {
       throw new RuntimeException("Not a valid directory: " + devicesDir.getAbsolutePath());
     }
 
-    String[] devices;
+    final String[] devices;
     if (specifiedDevices == null) {
       devices = devicesDir.list();
     } else {
       devices = devicesDir.list(new FilenameFilter() {
-      public boolean accept(File dir, String name) {
-        return specifiedDevices.contains(name);
-      }
+        public boolean accept(File dir, String name) {
+          return specifiedDevices.contains(name);
+        }
       });
     }
 

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
@@ -26,6 +26,7 @@ import com.google.daq.mqtt.util.ExceptionMap.ErrorTree;
 import com.google.daq.mqtt.util.PubSubPusher;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FilenameFilter;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.net.URI;
@@ -260,7 +261,7 @@ public class Registrar {
     AtomicInteger updatedCount = new AtomicInteger();
     AtomicInteger processedCount = new AtomicInteger();
     try {
-      localDevices = loadLocalDevices();
+      localDevices = loadLocalDevices(deviceSet);
       cloudDevices = fetchCloudDevices();
 
       if (deviceSet != null) {
@@ -508,13 +509,19 @@ public class Registrar {
     }
   }
 
-  private Map<String, LocalDevice> loadLocalDevices() {
+  private Map<String, LocalDevice> loadLocalDevices(Set<String> specifiedDevices) {
     Preconditions.checkNotNull(siteDir, "site directory");
     File devicesDir = new File(siteDir, DEVICES_DIR);
     if (!devicesDir.isDirectory()) {
       throw new RuntimeException("Not a valid directory: " + devicesDir.getAbsolutePath());
     }
-    String[] devices = devicesDir.list();
+
+    String[] devices = devicesDir.list(new FilenameFilter() {
+      public boolean accept(File dir, String name) {
+        return specifiedDevices.contains(name);
+      }
+    });
+
     Preconditions.checkNotNull(devices, "No devices found in " + devicesDir.getAbsolutePath());
     Map<String, LocalDevice> localDevices = loadDevices(siteDir, devicesDir, devices);
     writeNormalized(localDevices);

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
@@ -516,11 +516,16 @@ public class Registrar {
       throw new RuntimeException("Not a valid directory: " + devicesDir.getAbsolutePath());
     }
 
-    String[] devices = devicesDir.list(new FilenameFilter() {
+    String[] devices;
+    if (specifiedDevices == null) {
+      devices = devicesDir.list();
+    } else {
+      devices = devicesDir.list(new FilenameFilter() {
       public boolean accept(File dir, String name) {
         return specifiedDevices.contains(name);
       }
-    });
+      });
+    }
 
     Preconditions.checkNotNull(devices, "No devices found in " + devicesDir.getAbsolutePath());
     Map<String, LocalDevice> localDevices = loadDevices(siteDir, devicesDir, devices);

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
@@ -242,10 +242,6 @@ public class Registrar {
             cloudIotManager.getRegistryId()));
   }
 
-  private void processDevices() {
-    processDevices(null);
-  }
-
   private String getGenerationString() {
     try {
       Date generationDate = new Date();
@@ -254,6 +250,10 @@ public class Registrar {
     } catch (JsonProcessingException e) {
       throw new RuntimeException("While forming generation timestamp", e);
     }
+  }
+
+  private void processDevices() {
+    processDevices(null);
   }
 
   private void processDevices(List<String> devices) {


### PR DESCRIPTION
In the case that device names e.g. AHU-1 are supplied on argv to registrar, all devices are still processed.
This change filters devices to only match the ones requested.