### PR TITLE
Fix firebase function udmi_update for retrieving stored configs

### DIFF
--- a/dashboard/functions/index.js
+++ b/dashboard/functions/index.js
@@ -394,7 +394,7 @@ function consolidate_config(registryId, deviceId, subFolder) {
   const cloudRegion = registry_regions[registryId];
   const reg_doc = firestore.collection('registries').doc(registryId);
   const dev_doc = reg_doc.collection('devices').doc(deviceId);
-  const configs = dev_doc.collection('configs');
+  const configs = dev_doc.collection(CONFIG_TYPE);
 
   if (subFolder == UPDATE_FOLDER) {
     return;


### PR DESCRIPTION
The device config sub-blocks are stored in a firestore collection named 'config' (deprived from CONFIG_TYPE). Therefore, the `configs` is always empty.