### PR TITLE
add reflect region to pubber cloudiotconfig

### DIFF
--- a/pubber/src/main/java/com/google/daq/mqtt/util/CloudIotConfig.java
+++ b/pubber/src/main/java/com/google/daq/mqtt/util/CloudIotConfig.java
@@ -9,4 +9,5 @@ public class CloudIotConfig {
   public String cloud_region;
   public String site_name;
   public String update_topic;
+  public String reflect_region;
 }


### PR DESCRIPTION
to fix following error:

```
Exception in thread "main" java.lang.RuntimeException: While reading config file /Users/nournew/udmi_site_model/cloud_iot_config.json
	at daq.pubber.Pubber.loadCloudConfig(Pubber.java:325)
	at daq.pubber.Pubber.initializeDevice(Pubber.java:341)
	at daq.pubber.Pubber.initialize(Pubber.java:510)
	at daq.pubber.Pubber.singularPubber(Pubber.java:213)
	at daq.pubber.Pubber.main(Pubber.java:198)
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "reflect_region" (class com.google.daq.mqtt.util.CloudIotConfig), not marked as ignorable (4 known properties: "update_topic", "site_name", "registry_id", "cloud_region"])
 at [Source: (File); line: 5, column: 22] (through reference chain: com.google.daq.mqtt.util.CloudIotConfig["reflect_region"])
	at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:987)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:1974)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1701)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1679)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:330)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:187)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4593)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3413)
	at daq.pubber.Pubber.loadCloudConfig(Pubber.java:323)

```