### PR TITLE
change bin/clone_model output  into /sites directory from root

### DIFF
--- a/bin/clone_model
+++ b/bin/clone_model
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 
 ROOT_DIR=$(dirname $0)/..
-cd $ROOT_DIR
+mkdir -p $ROOT_DIR/sites
+cd $ROOT_DIR/sites 
 
 MODEL_DIR=udmi_site_model
 MODEL_VER=1.7

--- a/bin/test_registrar
+++ b/bin/test_registrar
@@ -5,7 +5,7 @@ cd ${ROOT_DIR}
 
 bin/clone_model
 
-TEST_SITE=udmi_site_model
+TEST_SITE=sites/udmi_site_model
 
 bin/registrar ${TEST_SITE}
 


### PR DESCRIPTION
Site models should be stored in the `sites` directory or a directory outside of the UDMI directory. 

This changes `bin/clone_model` to save the site model into the `sites` directory instead of the root UDMI directory