### PR TITLE
Change examples according to latest schema version 

### DIFF
--- a/tests/event_discovery.tests/continuous.json
+++ b/tests/event_discovery.tests/continuous.json
@@ -4,7 +4,7 @@
 // discovered {device_id} should be taken from the provided families.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "generation": "2018-08-26T22:00:13Z",
   "scan_family": "ipv6",

--- a/tests/event_discovery.tests/discovery.json
+++ b/tests/event_discovery.tests/discovery.json
@@ -4,7 +4,7 @@
 // discovered {device_id} should be taken from the provided families.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "generation": "2018-08-26T21:00:13Z",
   "scan_family": "ipv4",

--- a/tests/event_discovery.tests/enumeration.json
+++ b/tests/event_discovery.tests/enumeration.json
@@ -3,7 +3,7 @@
 // where {device_id} is that of the enumerated node.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:42:12.237Z",
   "generation": "2018-08-26T21:37:12Z",
   "points": {

--- a/tests/event_discovery.tests/errors.json
+++ b/tests/event_discovery.tests/errors.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "id": "sneakyCASE",
   "families": {

--- a/tests/event_discovery.tests/implicit.json
+++ b/tests/event_discovery.tests/implicit.json
@@ -7,7 +7,7 @@
 // of the enumerated node is provided by families.iot.id in the message payload.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "generation": "2018-08-26T21:37:12Z",
   "scan_family": "bacnet",

--- a/tests/event_discovery.tests/point_error.json
+++ b/tests/event_discovery.tests/point_error.json
@@ -7,7 +7,7 @@
 // of the enumerated node is provided by families.iot.id in the message payload.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "generation": "2018-08-26T21:37:12Z",
   "scan_family": "iot",

--- a/tests/event_discovery.tests/scan_error.json
+++ b/tests/event_discovery.tests/scan_error.json
@@ -4,7 +4,7 @@
 // discovered {device_id} should be taken from the provided families.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:42:12.237Z",
   "generation": "2018-08-26T21:37:12Z",
   "scan_family": "bacnet",

--- a/tests/event_pointset.tests/example.json
+++ b/tests/event_pointset.tests/example.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "points": {
     "reading_value": {

--- a/tests/event_pointset.tests/fcu.json
+++ b/tests/event_pointset.tests/fcu.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2019-01-17T14:02:29.364Z",
   "points": {
     "space_temperature_sensor": {

--- a/tests/event_system.tests/example.json
+++ b/tests/event_system.tests/example.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "logentries": [
     {

--- a/tests/event_system.tests/fcu.json
+++ b/tests/event_system.tests/fcu.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "logentries": [
     {

--- a/tests/state.tests/continuous.json
+++ b/tests/state.tests/continuous.json
@@ -3,7 +3,7 @@
 // where {device_id} is that of the discovery node.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
     "make_model": "ACME Bird Trap",

--- a/tests/state.tests/continuous.json
+++ b/tests/state.tests/continuous.json
@@ -6,9 +6,12 @@
   "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "make_model": "ACME Bird Trap",
-    "firmware": {
-      "version": "3.2a"
+    "hardware": {
+      "make": "ACME",
+      "model": "Bird Trap"
+    },
+    "software": {
+      "firmware": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",

--- a/tests/state.tests/discovery.json
+++ b/tests/state.tests/discovery.json
@@ -5,13 +5,14 @@
 {
   "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
-  "hardware": {
-    "make": "ACME",
-    "model": "Bird Trap"
-  },
-  "software": {
-    "firmware": "3.2a"
-  },
+  "system": {
+    "hardware": {
+      "make": "ACME",
+      "model": "Bird Trap"
+    },
+    "software": {
+      "firmware": "3.2a"
+    },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",
     "operational": true

--- a/tests/state.tests/discovery.json
+++ b/tests/state.tests/discovery.json
@@ -3,13 +3,15 @@
 // where {device_id} is that of the discovery node.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
-  "system": {
-    "make_model": "ACME Bird Trap",
-    "firmware": {
-      "version": "3.2a"
-    },
+  "hardware": {
+    "make": "ACME",
+    "model": "Bird Trap"
+  },
+  "software": {
+    "firmware": "3.2a"
+  },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",
     "operational": true

--- a/tests/state.tests/enumeration.json
+++ b/tests/state.tests/enumeration.json
@@ -6,9 +6,12 @@
   "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "make_model": "ACME Bird Trap",
-    "firmware": {
-      "version": "3.2a"
+    "hardware": {
+      "make": "ACME",
+      "model": "Bird Trap"
+    },
+    "software": {
+      "firmware": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",

--- a/tests/state.tests/enumeration.json
+++ b/tests/state.tests/enumeration.json
@@ -3,7 +3,7 @@
 // where {device_id} is that of the enumerated node.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
     "make_model": "ACME Bird Trap",

--- a/tests/state.tests/makemodel.json
+++ b/tests/state.tests/makemodel.json
@@ -1,13 +1,10 @@
 {
-  "version": "1.3.14",
+  "version": 1,
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "hardware": {
-      "make": "ACME",
-      "model": "Bird Trap"
-    },
-    "software": {
-      "firmware": "3.2a"
+    "make_model": "ACME Bird Trap",
+    "firmware": {
+      "version": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",

--- a/tests/state.tests/makemodel_error.json
+++ b/tests/state.tests/makemodel_error.json
@@ -2,12 +2,9 @@
   "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "hardware": {
-      "make": "ACME",
-      "model": "Bird Trap"
-    },
-    "software": {
-      "firmware": "3.2a"
+    "make_model": "ACME Bird Trap",
+    "firmware": {
+      "version": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",

--- a/tests/state.tests/makemodel_error.out
+++ b/tests/state.tests/makemodel_error.out
@@ -1,0 +1,3 @@
+2 schema violations found
+  object has missing required properties (["hardware","software"])
+  object instance has properties which are not allowed by the schema: ["firmware","make_model"]

--- a/tests/state.tests/makemodel_upgrade.json
+++ b/tests/state.tests/makemodel_upgrade.json
@@ -1,13 +1,10 @@
 {
-  "version": "1.3.14",
+  "version": 1,
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "hardware": {
-      "make": "ACME",
-      "model": "Bird Trap"
-    },
-    "software": {
-      "firmware": "3.2a"
+    "make_model": "ACME Bird Trap",
+    "firmware": {
+      "version": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",

--- a/tests/state.tests/periodic.json
+++ b/tests/state.tests/periodic.json
@@ -3,7 +3,7 @@
 // where {device_id} is that of the discovery node.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
     "make_model": "ACME Bird Trap",

--- a/tests/state.tests/periodic.json
+++ b/tests/state.tests/periodic.json
@@ -6,9 +6,12 @@
   "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "make_model": "ACME Bird Trap",
-    "firmware": {
-      "version": "3.2a"
+    "hardware": {
+      "make": "ACME",
+      "model": "Bird Trap"
+    },
+    "software": {
+      "firmware": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",

--- a/tests/state.tests/scan_bad.json
+++ b/tests/state.tests/scan_bad.json
@@ -3,7 +3,7 @@
 // where {device_id} is that of the discovery node.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
     "make_model": "ACME Bird Trap",

--- a/tests/state.tests/scan_bad.json
+++ b/tests/state.tests/scan_bad.json
@@ -6,9 +6,12 @@
   "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "make_model": "ACME Bird Trap",
-    "firmware": {
-      "version": "3.2a"
+    "hardware": {
+      "make": "ACME",
+      "model": "Bird Trap"
+    },
+    "software": {
+      "firmware": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",

--- a/tests/state.tests/scan_error.json
+++ b/tests/state.tests/scan_error.json
@@ -3,7 +3,7 @@
 // where {device_id} is that of the discovery node.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
     "make_model": "ACME Bird Trap",

--- a/tests/state.tests/scan_error.json
+++ b/tests/state.tests/scan_error.json
@@ -6,9 +6,12 @@
   "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "make_model": "ACME Bird Trap",
-    "firmware": {
-      "version": "3.2a"
+    "hardware": {
+      "make": "ACME",
+      "model": "Bird Trap"
+    },
+    "software": {
+      "firmware": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",

--- a/tests/state.tests/scan_stop.json
+++ b/tests/state.tests/scan_stop.json
@@ -3,7 +3,7 @@
 // where {device_id} is that of the discovery node.
 //
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
     "make_model": "ACME Bird Trap",

--- a/tests/state.tests/scan_stop.json
+++ b/tests/state.tests/scan_stop.json
@@ -6,9 +6,12 @@
   "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "make_model": "ACME Bird Trap",
-    "firmware": {
-      "version": "3.2a"
+    "hardware": {
+      "make": "ACME",
+      "model": "Bird Trap"
+    },
+    "software": {
+      "firmware": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:49:29.364Z",

--- a/tests/state.tests/writeback.json
+++ b/tests/state.tests/writeback.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
     "make_model": "ACME Bird Trap",

--- a/tests/state.tests/writeback.json
+++ b/tests/state.tests/writeback.json
@@ -2,9 +2,12 @@
   "version": "1.3.14",
   "timestamp": "2018-08-26T21:39:29.364Z",
   "system": {
-    "make_model": "ACME Bird Trap",
-    "firmware": {
-      "version": "3.2a"
+    "hardware": {
+      "make": "ACME",
+      "model": "Bird Trap"
+    },
+    "software": {
+      "firmware": "3.2a"
     },
     "serial_no": "182732142",
     "last_config": "2018-08-26T21:38:29.364Z",


### PR DESCRIPTION
- Adds tests to cover validator message upgrader (new version but old schema and vice versa)
- Upgrade existing examples to match latest schema (string `version`, `hardware`/`software` instead of `make_model`/`firmware`