### PR TITLE
make pubsub pusher optional

### DIFF
--- a/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
+++ b/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
@@ -264,7 +264,9 @@ public class Validator {
   private void validatePubSub(String instName) {
     String registryId = cloudIotConfig.registry_id;
     client = new PubSubClient(projectId, registryId, instName);
-    dataSink = new PubSubDataSink(projectId, cloudIotConfig.update_topic);
+    if (cloudIotManager.getUpdateTopic() != null) {
+      dataSink = new PubSubDataSink(projectId, cloudIotConfig.update_topic);
+    }
   }
 
   private void validateReflector(String instName) {


### PR DESCRIPTION
Fix following error when running the validator by making the pubsub pusher optional [as it is in registrar](https://github.com/faucetsdn/udmi/blob/0632590bd203526419205e96d17fa60077f04a64/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java#L239)
```
Created service for project projects/daq1-273309/locations/us-central1
Resetting and connecting to pubsub subscription projects/daq1-273309/subscriptions/udmi_target
Resetting existing subscription projects/daq1-273309/subscriptions/udmi_target
java.lang.RuntimeException: While creating PubSubPublisher
	at com.google.daq.mqtt.util.PubSubPusher.<init>(PubSubPusher.java:43)
	at com.google.daq.mqtt.util.PubSubDataSink.<init>(PubSubDataSink.java:35)
	at com.google.daq.mqtt.validator.Validator.validatePubSub(Validator.java:267)
	at com.google.daq.mqtt.validator.Validator.main(Validator.java:143)
Caused by: java.lang.NullPointerException: PubSub publish topic
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:899)
	at com.google.daq.mqtt.util.PubSubPusher.<init>(PubSubPusher.java:37)
	... 3 more
Validation complete, exit 255

```