### PR TITLE
add npm install to deploy_dashboard_firebase

### DIFF
--- a/dashboard/deploy_dashboard_firebase
+++ b/dashboard/deploy_dashboard_firebase
@@ -15,6 +15,8 @@ version=`git describe --dirty`
 echo Deploying version $version to $PROJECT
 echo "const udmi_deploy_version = '$version';" > public/deploy_version.js
 
+npm install --prefix ./functions
+
 firebase use $PROJECT
 
 only="functions:udmi_target"


### PR DESCRIPTION
Avoids the requirement to run `npm install` within the functions directory prior to deployment.