### PR TITLE
pass arguments to gcloud deploy

### DIFF
--- a/dashboard/deploy_dashboard_gcloud
+++ b/dashboard/deploy_dashboard_gcloud
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-if [ $# != 1 ]; then
-    echo Usage: $0 [project_id]
+if (( $# < 1 )); then
+    echo Usage: $0 PROJECT_ID [options]
     false
 fi
 
@@ -27,7 +27,7 @@ EOF
 PUBSUB_FUNCTIONS="udmi_target udmi_state udmi_config udmi_reflect"
 for func in $PUBSUB_FUNCTIONS; do
     echo Deploying pubsub-trigger function $func...
-    gcloud functions deploy $func --set-env-vars GCP_PROJECT=$PROJECT --trigger-topic=$func --runtime=$RUNTIME --project=$PROJECT --source=$SOURCE &
+    gcloud functions deploy $func --set-env-vars GCP_PROJECT=$PROJECT --trigger-topic=$func --runtime=$RUNTIME --project=$PROJECT --source=$SOURCE "$@" &
     sleep 10
 done
 


### PR DESCRIPTION
I needed this so I can deploy the gcloud functions with the non-default service account (the default service account has editor role over a project by default).

Just passes the arguments onto the `gcloud deploy` call, so [gcloud deploy parameters](https://cloud.google.com/sdk/gcloud/reference/functions/deploy) can be used. I only needed `service-account`, but figured power users may want to modify some of the other parameters too