### PR TITLE
add pubber missingPoint and noConfigAck options

### DIFF
--- a/docs/tools/pubber.md
+++ b/docs/tools/pubber.md
@@ -28,10 +28,16 @@ The following parameters are currently supported from the CLI:
 * `extraPoint=<name>` - adds an extra point with the given name to the device
   which does not exist in device's metadata with a random value (will trigger
   validation additional point error)
+* `missingPoint=<name>` - removes the point with the given name (if exists) from
+  the device's active pointset at initialization  (will trigger validation
+  missing point)
 * `extraField=<name>` - adds an extra schema invalidating field to pointset events
   (will trigger validation schema error)
-* `no_hardware` - omits the `system.hardware` field from state messages (will
+* `noHardware` - omits the `system.hardware` field from state messages (will
   trigger validation error, missing required field)
+* `noConfigAck` - subscribes to the `config` topic with a QoS of 0, therefore
+  will not send PUBACK's for config messages
+
 
 More advanced options can be set by by calling pubber directly with the path a
 configuration file: `pubber/bin/run path/to/config.json`

--- a/pubber/src/main/java/daq/pubber/ConfigurationOptions.java
+++ b/pubber/src/main/java/daq/pubber/ConfigurationOptions.java
@@ -5,7 +5,9 @@ package daq.pubber;
  */
 public class ConfigurationOptions {
   public Boolean noHardware;
+  public Boolean noConfigAck;
   public String extraPoint;
+  public String missingPoint;
   public String extraField;
 
 }

--- a/pubber/src/main/java/daq/pubber/MqttPublisher.java
+++ b/pubber/src/main/java/daq/pubber/MqttPublisher.java
@@ -286,7 +286,11 @@ public class MqttPublisher {
   }
 
   private void subscribeToUpdates(MqttClient client, String deviceId) {
-    subscribeTopic(client, String.format(CONFIG_UPDATE_TOPIC_FMT, deviceId), QOS_AT_LEAST_ONCE);
+    Integer configQOS = QOS_AT_LEAST_ONCE; // Defaults to QoS 1
+    if (configuration.options.noConfigAck) {
+      configQOS = QOS_AT_MOST_ONCE;
+    }
+    subscribeTopic(client, String.format(CONFIG_UPDATE_TOPIC_FMT, deviceId), configQOS);
     subscribeTopic(client, String.format(ERRORS_TOPIC_FMT, deviceId), QOS_AT_MOST_ONCE);
     info("Updates subscribed");
   }

--- a/pubber/src/main/java/daq/pubber/MqttPublisher.java
+++ b/pubber/src/main/java/daq/pubber/MqttPublisher.java
@@ -287,7 +287,7 @@ public class MqttPublisher {
 
   private void subscribeToUpdates(MqttClient client, String deviceId) {
     Integer configQOS = QOS_AT_LEAST_ONCE; // Defaults to QoS 1
-    if (configuration.options.noConfigAck) {
+    if (configuration.options.noConfigAck != null && configuration.options.noConfigAck) {
       configQOS = QOS_AT_MOST_ONCE;
     }
     subscribeTopic(client, String.format(CONFIG_UPDATE_TOPIC_FMT, deviceId), configQOS);

--- a/pubber/src/main/java/daq/pubber/Pubber.java
+++ b/pubber/src/main/java/daq/pubber/Pubber.java
@@ -301,6 +301,15 @@ public class Pubber {
 
     Map<String, PointPointsetModel> points =
         metadata.pointset == null ? DEFAULT_POINTS : metadata.pointset.points;
+
+    if (configuration.options.missingPoint != null) {
+      if (points.contains(configuration.options.missingPoint)) {
+        points.remove(configuration.options.missingPoint);
+      } else {
+        throw new RuntimeException("missingPoint not in pointset");
+      }
+    } 
+
     points.forEach((name, point) -> addPoint(makePoint(name, point)));
   }
 

--- a/pubber/src/main/java/daq/pubber/Pubber.java
+++ b/pubber/src/main/java/daq/pubber/Pubber.java
@@ -303,7 +303,7 @@ public class Pubber {
         metadata.pointset == null ? DEFAULT_POINTS : metadata.pointset.points;
 
     if (configuration.options.missingPoint != null) {
-      if (points.contains(configuration.options.missingPoint)) {
+      if (points.containsKey(configuration.options.missingPoint)) {
         points.remove(configuration.options.missingPoint);
       } else {
         throw new RuntimeException("missingPoint not in pointset");


### PR DESCRIPTION
Adds missingPoint option to remove a point from pubber, and a noConfigAck option which sets config subscription QoS to 0 (therefore no puback)