### PR TITLE
change cloud function targets to constants

### DIFF
--- a/dashboard/deploy_dashboard_gcloud
+++ b/dashboard/deploy_dashboard_gcloud
@@ -11,6 +11,30 @@ cd $ROOT/dashboard
 PROJECT=$1
 shift
 
+udmi_state=udmi_state
+udmi_reflect=udmi_reflect
+udmi_target=udmi_target
+udmi_config=udmi_config
+
+append_env_var () {
+   extra_args="$extra_args --set-env-vars $1=$2"
+} 
+
+while (( $# > 0 )) ; do
+    k=$(echo $1 | cut -d'=' -f1)
+    v=$(echo $1 | cut -d'=' -f2)
+
+  case $k in
+    --udmi_state) udmi_state=$v && append_env_var UDMI_STATE $v;;
+    --udmi_reflect) udmi_reflect=$v && append_env_var UDMI_REFLECT $v;;
+    --udmi_target) udmi_target=$v && append_env_var UDMI_TARGET $v;;
+    --udmi_config) udmi_config=$v && append_env_var UDMI_CONFIG $v;;
+    --reflect_registry) append_env_var REFLECT_REGISTRY $v;;
+    --service_account) extra_args="$extra_args --service_account=$v"
+  esac
+  shift
+done
+
 RUNTIME=nodejs12
 SOURCE=functions/
 
@@ -26,8 +50,16 @@ EOF
 
 PUBSUB_FUNCTIONS="udmi_target udmi_state udmi_config udmi_reflect"
 for func in $PUBSUB_FUNCTIONS; do
-    echo Deploying pubsub-trigger function $func...
-    gcloud functions deploy $func --set-env-vars GCP_PROJECT=$PROJECT --trigger-topic=$func --runtime=$RUNTIME --project=$PROJECT --source=$SOURCE "$@" &
+    echo Deploying pubsub-trigger function $func as ${!func}...
+
+    gcloud functions deploy ${!func} \
+      --set-env-vars GCP_PROJECT=$PROJECT \
+      --trigger-topic=${!func}  \
+      --runtime=$RUNTIME \
+      --project=$PROJECT \
+      --source=$SOURCE \
+      --entry-point=$func \
+      $extra_args &
     sleep 10
 done
 

--- a/dashboard/functions/index.js
+++ b/dashboard/functions/index.js
@@ -10,10 +10,10 @@ if (!process.env.GCLOUD_PROJECT) {
   process.env.GCLOUD_PROJECT = PROJECT_ID;
 }
 
-const UDMI_TARGET = process.env.UDMI_TARGET || 'udmi_target'
-const UDMI_STATE = process.env.UDMI_STATE || 'udmi_state'
-const UDMI_REFLECT = process.env.UDMI_REFLECT || 'udmi_reflect'
-const UDMI_CONFIG = process.env.UDMI_CONFIG || 'udmi_config'
+const UDMI_TARGET = process.env.UDMI_TARGET || 'udmi_target';
+const UDMI_STATE = process.env.UDMI_STATE || 'udmi_state';
+const UDMI_REFLECT = process.env.UDMI_REFLECT || 'udmi_reflect';
+const UDMI_CONFIG = process.env.UDMI_CONFIG || 'udmi_config';
 const REFLECT_REGISTRY =  process.env.REFLECT_REGISTRY ||'UDMS-REFLECT';
 
 const version = require('./version');


### PR DESCRIPTION
Allows cloud functions and trigger topics to be renamed

Deploy instructions:

`dashboard/deploy_dashboard_gcloud daq1-273309 --udmi_state=state4 --udmi_target=target4 --udmi_config=config4 --udmi_reflect=reflect4`