### PR TITLE
Windows filesystem fix

### DIFF
--- a/schema/model_system.json
+++ b/schema/model_system.json
@@ -76,6 +76,7 @@
       ]
     },
     "aux": {
+      "title": "auxiliary",
       "type": "object",
       "additionalProperties": false,
       "properties": {


### PR DESCRIPTION
Avoiding the metadata.system.aux key to be named Aux in the Java class name and file name, because in Windows filesystems it is forbidden to name a file as AUX or any of its different letter case variations.