### PR TITLE
Improve clarity in config message documentation page

### DIFF
--- a/docs/messages/config.md
+++ b/docs/messages/config.md
@@ -17,20 +17,28 @@ It is composed of specific sub-entries for each sub-system { _system_, _pointset
 This [working example](../../tests/config.tests/example.json) shows how a typical `config` message
 is constructed.
 
-## Config Message
+## Config Parameters
+
+### System
+* `min_loglevel`: Indicates the minimum loglevel for reporting log messages below which log entries
+should not be sent. See note below for a description of the level value.
+
+### Pointset
 
 * `sample_rate_sec`: Sampling rate for the system, which should proactively send an
 update (e.g. _pointset_, _logentry_, _discover_ message) at this interval.
 * `sample_limit_sec`: Minimum time between sample updates. Updates that happen faster than this time
 (e.g. due to _cov_ events) should be coalesced so that only the most recent update is sent.
+
+#### Point
+
 * `set_value`: Set a value to be used during diagnostics and operational use. Should
 override any operational values, but not override alarm conditions.
-* `min_loglevel`: Indicates the minimum loglevel for reporting log messages below which log entries
-should not be sent. See note below for a description of the level value.
 
-## Config Entries
+## Config Log Entries
 
-During a config up sequence, the system should produce the following log/status update entries:
-
-* system.config.update
+During a config receive/up sequence, the system should produce the following log/status update entries:
+* _system.config.receive_: (**DEBUG**) Receiving a config message
+* _system.config.parse_: (**DEBUG**) Parsing a received message
+* _system.config.apply_: (**NOTICE**) Application of a parsed config message
 


### PR DESCRIPTION
Corrected:
- page suggested sample_rate_secs applied to the entire which was incorrect
- page gave incorrect log categories