### PR TITLE
Add shell exit traps for EXIT cleanup

### DIFF
--- a/bin/pubber
+++ b/bin/pubber
@@ -1,10 +1,10 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 ROOT_DIR=$(realpath $(dirname $0)/..)
 
 function cleanup {
     echo Killing pubber children...
-    kill 0
+    #kill 0
 }
 trap cleanup EXIT
 

--- a/bin/pubber
+++ b/bin/pubber
@@ -2,6 +2,12 @@
 
 ROOT_DIR=$(realpath $(dirname $0)/..)
 
+function cleanup {
+    echo Killing pubber children...
+    kill 0
+}
+trap cleanup EXIT
+
 if (( $# < 4 )); then
     echo $0 SITE_PATH PROJECT_ID DEVICE_ID SERIAL_NO [options] ...
     false

--- a/bin/pubber
+++ b/bin/pubber
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 ROOT_DIR=$(realpath $(dirname $0)/..)
 

--- a/bin/pubber
+++ b/bin/pubber
@@ -3,8 +3,10 @@
 ROOT_DIR=$(realpath $(dirname $0)/..)
 
 function cleanup {
-    echo Killing pubber children...
-    #kill 0
+    if [[ -n $PUB_PID ]]; then
+        echo Killing pubber runner $PUB_PID
+        kill $PUB_PID
+    fi
 }
 trap cleanup EXIT
 
@@ -62,4 +64,7 @@ cat <<EOF > /tmp/pubber_config.json
 }
 EOF
 
-$ROOT_DIR/pubber/bin/run /tmp/pubber_config.json
+# Run in the background to force new process group and get PID
+$ROOT_DIR/pubber/bin/run /tmp/pubber_config.json &
+PUB_PID=$!
+wait

--- a/bin/test_redirect
+++ b/bin/test_redirect
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 ROOT_DIR=$(dirname $0)/..
 cd $ROOT_DIR

--- a/bin/test_redirect
+++ b/bin/test_redirect
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 ROOT_DIR=$(dirname $0)/..
 cd $ROOT_DIR

--- a/pubber/bin/run
+++ b/pubber/bin/run
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 ROOT_DIR=$(realpath $(dirname $0)/../..)
 

--- a/pubber/bin/run
+++ b/pubber/bin/run
@@ -2,6 +2,14 @@
 
 ROOT_DIR=$(realpath $(dirname $0)/../..)
 
+function cleanup {
+    if [[ -n $PUB_PID ]]; then
+        echo Killing pubber pid $PUB_PID
+        kill $PUB_PID
+    fi
+}
+trap cleanup EXIT
+
 result=192  # Exit code used to indicate intentional system restart.
 
 while [[ $result -eq 192 ]]; do

--- a/pubber/bin/run
+++ b/pubber/bin/run
@@ -1,11 +1,11 @@
-#!/bin/bash -e
+#!/bin/bash -ex
 
 ROOT_DIR=$(realpath $(dirname $0)/../..)
 
 function cleanup {
     if [[ -n $PUB_PID ]]; then
         echo Killing pubber pid $PUB_PID
-        kill $PUB_PID
+        #kill $PUB_PID
     fi
 }
 trap cleanup EXIT

--- a/pubber/bin/run
+++ b/pubber/bin/run
@@ -4,8 +4,8 @@ ROOT_DIR=$(realpath $(dirname $0)/../..)
 
 function cleanup {
     if [[ -n $PUB_PID ]]; then
-        echo Killing pubber pid $PUB_PID
-        #kill $PUB_PID
+        echo Killing pubber instance $PUB_PID
+        kill $PUB_PID
     fi
 }
 trap cleanup EXIT


### PR DESCRIPTION
Makes it so that ^C or a "kill SIGINT" against any of the processes exits cleanly. (There's the core java program, the java wrapper, and test runner.)