### PR TITLE
Adding provision to clean out alternate config

### DIFF
--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
@@ -42,7 +42,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -70,7 +69,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 import org.junit.rules.Timeout;
-import org.junit.runner.Description;
 import org.junit.runners.model.TestTimedOutException;
 import udmi.schema.Bucket;
 import udmi.schema.Config;
@@ -1242,8 +1240,16 @@ public class SequenceBase {
     }
   }
 
-  protected void mirrorDeviceConfig() {
-    String receivedConfig = actualize(stringify(receivedUpdates.get(CONFIG_SUBTYPE)));
+  protected void mirrorToOtherConfig() {
+    updateConfig("mirroring config");
+    updateMirrorConfig(actualize(stringify(receivedUpdates.get(CONFIG_SUBTYPE))));
+  }
+
+  protected void clearOtherConfig() {
+    updateMirrorConfig("{}");
+  }
+
+  private void updateMirrorConfig(String receivedConfig) {
     String topic = UPDATE_SUBFOLDER + "/" + CONFIG_SUBTYPE;
     reflector(!useAlternateClient).publish(getDeviceId(), topic, receivedConfig);
     // There's a race condition if the mirror command gets delayed, so chill for a bit.

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
@@ -1240,6 +1240,12 @@ public class SequenceBase {
     }
   }
 
+  /**
+   * Mirrors the current config to the "other" config, where the current and
+   * other configs are defined by the useAlternateClient flag. This call is used
+   * to warm-up the new config before a switch, so that when the client is switched,
+   * it is ready with the right (up to date) config contents.
+   */
   protected void mirrorToOtherConfig() {
     updateConfig("mirroring config " + useAlternateClient);
     Config target = (Config) receivedUpdates.get(CONFIG_SUBTYPE);
@@ -1248,6 +1254,11 @@ public class SequenceBase {
     updateMirrorConfig(actualize(stringify(target)));
   }
 
+  /**
+   * Clears out the "other" (not current) config, so that it can't be inadvertantly used
+   * for something. This is the simple version of the endpoint going down (actually turning
+   * down the endpoint would be a lot more work).
+   */
   protected void clearOtherConfig() {
     updateMirrorConfig("{}");
   }

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
@@ -1241,8 +1241,11 @@ public class SequenceBase {
   }
 
   protected void mirrorToOtherConfig() {
-    updateConfig("mirroring config");
-    updateMirrorConfig(actualize(stringify(receivedUpdates.get(CONFIG_SUBTYPE))));
+    updateConfig("mirroring config " + useAlternateClient);
+    Config target = (Config) receivedUpdates.get(CONFIG_SUBTYPE);
+    // Since this is updating the mirror, use the opposite of what it would be locally.
+    target.system.testing.endpoint_type = useAlternateClient ? null : "alternate";
+    updateMirrorConfig(actualize(stringify(target)));
   }
 
   protected void clearOtherConfig() {

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/BlobsetSequences.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/BlobsetSequences.java
@@ -205,41 +205,6 @@ public class BlobsetSequences extends SequenceBase {
   }
 
   @Test
-  @Description("Check connection to an alternate project with restart.")
-  public void endpoint_redirect_and_restart() {
-    if (altRegistry == null) {
-      throw new SkipTest("No alternate registry defined");
-    }
-
-    // Phase one: initiate connection to alternate registry.
-    untilTrue("initial last_config matches config timestamp", this::stateMatchesConfigTimestamp);
-    setDeviceConfigEndpointBlob(GOOGLE_ENDPOINT_HOSTNAME, altRegistry, false);
-    untilSuccessfulRedirect(BlobPhase.APPLY);
-
-    withAlternateClient(() -> {
-      // Phase two: verify connection to alternate registry.
-      untilSuccessfulRedirect(BlobPhase.FINAL);
-      untilTrue("alternate last_config matches config timestamp",
-          this::stateMatchesConfigTimestamp);
-      untilClearedRedirect();
-
-      system_mode_restart();
-
-      // Phase three: initiate connection back to initial registry.
-      // Phase 3/4 test the same thing as phase 1/2, included to restore system to initial state.
-      setDeviceConfigEndpointBlob(GOOGLE_ENDPOINT_HOSTNAME, registryId, false);
-      untilSuccessfulRedirect(BlobPhase.APPLY);
-    });
-
-    // Phase four: verify restoration of initial registry connection.
-    whileDoing("restoring main connection", () -> {
-      untilSuccessfulRedirect(BlobPhase.FINAL);
-      untilTrue("restored last_config matches config timestamp", this::stateMatchesConfigTimestamp);
-      untilClearedRedirect();
-    });
-  }
-
-  @Test
   @Description("Restart and connect to same endpoint and expect it returns.")
   @Feature(stage = STABLE, bucket = SYSTEM_MODE)
   public void system_mode_restart() {

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/BlobsetSequences.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/BlobsetSequences.java
@@ -202,6 +202,46 @@ public class BlobsetSequences extends SequenceBase {
   }
 
   @Test
+  @Description("Check connection to an alternate project with restart.")
+  public void endpoint_redirect_and_restart() {
+    if (altRegistry == null) {
+      throw new SkipTest("No alternate registry defined");
+    }
+    clearOtherConfig();
+
+    // Phase one: initiate connection to alternate registry.
+    untilTrue("initial last_config matches config timestamp", this::stateMatchesConfigTimestamp);
+    setDeviceConfigEndpointBlob(GOOGLE_ENDPOINT_HOSTNAME, altRegistry, false);
+    mirrorToOtherConfig();
+    untilSuccessfulRedirect(BlobPhase.APPLY);
+
+    withAlternateClient(() -> {
+      // Phase two: verify connection to alternate registry.
+      untilSuccessfulRedirect(BlobPhase.FINAL);
+      clearOtherConfig();  // Clears out the original config so it can't be re-used.
+      untilTrue("alternate last_config matches config timestamp",
+          this::stateMatchesConfigTimestamp);
+      untilClearedRedirect();
+
+      system_mode_restart();
+      
+      // Phase three: initiate connection back to initial registry.
+      // Phase 3/4 test the same thing as phase 1/2, included to restore system to initial state.
+      setDeviceConfigEndpointBlob(GOOGLE_ENDPOINT_HOSTNAME, registryId, false);
+      mirrorToOtherConfig();
+      untilSuccessfulRedirect(BlobPhase.APPLY);
+    });
+
+    // Phase four: verify restoration of initial registry connection.
+    whileDoing("restoring main connection", () -> {
+      untilSuccessfulRedirect(BlobPhase.FINAL);
+      clearOtherConfig();  // Clears out the alternate config so we don't get confused.
+      untilTrue("restored last_config matches config timestamp", this::stateMatchesConfigTimestamp);
+      untilClearedRedirect();
+    });
+  }
+
+  @Test
   @Description("Restart and connect to same endpoint and expect it returns.")
   @Feature(stage = STABLE, bucket = SYSTEM_MODE)
   public void system_mode_restart() {

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/BlobsetSequences.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/BlobsetSequences.java
@@ -205,6 +205,41 @@ public class BlobsetSequences extends SequenceBase {
   }
 
   @Test
+  @Description("Check connection to an alternate project with restart.")
+  public void endpoint_redirect_and_restart() {
+    if (altRegistry == null) {
+      throw new SkipTest("No alternate registry defined");
+    }
+
+    // Phase one: initiate connection to alternate registry.
+    untilTrue("initial last_config matches config timestamp", this::stateMatchesConfigTimestamp);
+    setDeviceConfigEndpointBlob(GOOGLE_ENDPOINT_HOSTNAME, altRegistry, false);
+    untilSuccessfulRedirect(BlobPhase.APPLY);
+
+    withAlternateClient(() -> {
+      // Phase two: verify connection to alternate registry.
+      untilSuccessfulRedirect(BlobPhase.FINAL);
+      untilTrue("alternate last_config matches config timestamp",
+          this::stateMatchesConfigTimestamp);
+      untilClearedRedirect();
+
+      system_mode_restart();
+
+      // Phase three: initiate connection back to initial registry.
+      // Phase 3/4 test the same thing as phase 1/2, included to restore system to initial state.
+      setDeviceConfigEndpointBlob(GOOGLE_ENDPOINT_HOSTNAME, registryId, false);
+      untilSuccessfulRedirect(BlobPhase.APPLY);
+    });
+
+    // Phase four: verify restoration of initial registry connection.
+    whileDoing("restoring main connection", () -> {
+      untilSuccessfulRedirect(BlobPhase.FINAL);
+      untilTrue("restored last_config matches config timestamp", this::stateMatchesConfigTimestamp);
+      untilClearedRedirect();
+    });
+  }
+
+  @Test
   @Description("Restart and connect to same endpoint and expect it returns.")
   @Feature(stage = STABLE, bucket = SYSTEM_MODE)
   public void system_mode_restart() {


### PR DESCRIPTION
Nukes the not-in-use config to prevent it inadvertently being used to bounce around from a not-used endpoint.