### PR TITLE
Fix processing for hidden or temporary device files

### DIFF
--- a/common/src/main/java/com/google/udmi/util/SiteModel.java
+++ b/common/src/main/java/com/google/udmi/util/SiteModel.java
@@ -1,6 +1,7 @@
 package com.google.udmi.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -8,9 +9,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -100,6 +103,17 @@ public class SiteModel {
     return clientInfo;
   }
 
+  public static List<String> listDevices(File devicesDir) {
+    if (!devicesDir.exists()) {
+      System.err.println(
+          "Directory not found, assuming no devices: " + devicesDir.getAbsolutePath());
+      return ImmutableList.of();
+    }
+    String[] devices = requireNonNull(devicesDir.list());
+    return Arrays.stream(devices).filter(SiteModel::validDeviceDirectory)
+        .collect(Collectors.toList());
+  }
+
   public EndpointConfiguration makeEndpointConfig(String projectId, String deviceId) {
     return makeEndpointConfig(projectId, executionConfiguration, deviceId);
   }
@@ -111,7 +125,7 @@ public class SiteModel {
     return Arrays.stream(files).map(File::getName).filter(SiteModel::validDeviceDirectory).collect(Collectors.toSet());
   }
 
-  public static boolean validDeviceDirectory(String dirName) {
+  private static boolean validDeviceDirectory(String dirName) {
     return !(dirName.startsWith(".") || dirName.endsWith("~"));
   }
 

--- a/gencode/java/udmi/schema/ValidationSummary.java
+++ b/gencode/java/udmi/schema/ValidationSummary.java
@@ -1,12 +1,12 @@
 
 package udmi.schema;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.annotation.processing.Generated;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
 
 
 /**

--- a/tests/downgrade.site/devices/.dummy_bad_device/metadata.json
+++ b/tests/downgrade.site/devices/.dummy_bad_device/metadata.json
@@ -1,0 +1,1 @@
+This file is here to test that this directory is NOT scanned by the tools.

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
@@ -25,7 +25,6 @@ import com.google.udmi.util.SiteModel;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FilenameFilter;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.math.BigInteger;
@@ -33,7 +32,6 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
@@ -565,18 +563,8 @@ public class Registrar {
   }
 
   private List<String> getDeviceList(Set<String> specifiedDevices, File devicesDir) {
-    final String[] devices;
-    if (specifiedDevices == null) {
-      devices = devicesDir.list();
-    } else {
-      devices = devicesDir.list(new FilenameFilter() {
-        public boolean accept(File dir, String name) {
-          return specifiedDevices.contains(name);
-        }
-      });
-    }
-    Preconditions.checkNotNull(devices, "No devices found in " + devicesDir.getAbsolutePath());
-    return Arrays.stream(devices).filter(SiteModel::validDeviceDirectory)
+    return SiteModel.listDevices(devicesDir).stream()
+        .filter(name -> specifiedDevices == null || specifiedDevices.contains(name))
         .collect(Collectors.toList());
   }
 

--- a/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
+++ b/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
@@ -14,7 +14,6 @@ import static com.google.daq.mqtt.util.ConfigUtil.UDMI_VERSION;
 import static com.google.daq.mqtt.util.ConfigUtil.readExecutionConfiguration;
 import static com.google.udmi.util.JsonUtil.JSON_SUFFIX;
 import static com.google.udmi.util.JsonUtil.OBJECT_MAPPER;
-import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -313,7 +312,7 @@ public class Validator {
 
   private void initializeExpectedDevices(String siteDir) {
     File devicesDir = new File(siteDir, DEVICES_SUBDIR);
-    List<String> strings = getDevices(devicesDir);
+    List<String> strings = SiteModel.listDevices(devicesDir);
     try {
       for (String device : strings) {
         ReportingDevice reportingDevice = new ReportingDevice(device);
@@ -332,17 +331,6 @@ public class Validator {
       throw new RuntimeException(
           "While loading devices directory " + devicesDir.getAbsolutePath(), e);
     }
-  }
-
-  private List<String> getDevices(File devicesDir) {
-    if (!devicesDir.exists()) {
-      System.err.println(
-          "Directory not found, assuming no devices: " + devicesDir.getAbsolutePath());
-      return ImmutableList.of();
-    }
-    String[] devices = requireNonNull(devicesDir.list());
-    return Arrays.stream(devices).filter(SiteModel::validDeviceDirectory)
-        .collect(Collectors.toList());
   }
 
   /**

--- a/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
+++ b/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
@@ -312,9 +312,9 @@ public class Validator {
 
   private void initializeExpectedDevices(String siteDir) {
     File devicesDir = new File(siteDir, DEVICES_SUBDIR);
-    List<String> strings = SiteModel.listDevices(devicesDir);
+    List<String> siteDevices = SiteModel.listDevices(devicesDir);
     try {
-      for (String device : strings) {
+      for (String device : siteDevices) {
         ReportingDevice reportingDevice = new ReportingDevice(device);
         try {
           File deviceDir = new File(devicesDir, device);

--- a/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
+++ b/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
@@ -43,6 +43,7 @@ import com.google.daq.mqtt.util.PubSubClient;
 import com.google.daq.mqtt.util.ValidationException;
 import com.google.udmi.util.GeneralUtils;
 import com.google.udmi.util.JsonUtil;
+import com.google.udmi.util.SiteModel;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -312,13 +313,9 @@ public class Validator {
 
   private void initializeExpectedDevices(String siteDir) {
     File devicesDir = new File(siteDir, DEVICES_SUBDIR);
-    if (!devicesDir.exists()) {
-      System.err.println(
-          "Directory not found, assuming no devices: " + devicesDir.getAbsolutePath());
-      return;
-    }
+    List<String> strings = getDevices(devicesDir);
     try {
-      for (String device : requireNonNull(devicesDir.list())) {
+      for (String device : strings) {
         ReportingDevice reportingDevice = new ReportingDevice(device);
         try {
           File deviceDir = new File(devicesDir, device);
@@ -335,6 +332,17 @@ public class Validator {
       throw new RuntimeException(
           "While loading devices directory " + devicesDir.getAbsolutePath(), e);
     }
+  }
+
+  private List<String> getDevices(File devicesDir) {
+    if (!devicesDir.exists()) {
+      System.err.println(
+          "Directory not found, assuming no devices: " + devicesDir.getAbsolutePath());
+      return ImmutableList.of();
+    }
+    String[] devices = requireNonNull(devicesDir.list());
+    return Arrays.stream(devices).filter(SiteModel::validDeviceDirectory)
+        .collect(Collectors.toList());
   }
 
   /**


### PR DESCRIPTION
Addresses situations where there's a hidden folder in the devices/ directory (e.g. .DS_store from mac) and/or temporary edit files (i.e. trailing ~). Filters them out so they're not considered valid "devices" for the tools.