### PR TITLE
adding possibility to push to alternative image registry

### DIFF
--- a/udmis/bin/container
+++ b/udmis/bin/container
@@ -6,17 +6,25 @@ DROOT=.
 
 function usage {
     echo Error: $*
-    echo Usage: $0 { build, shell, run, push, deploy, update, status, logs, stop }
+    echo Usage: $0 { build, shell, run, push, deploy, update, status, logs, stop } [repo]
     echo Project: $PROJECT
     exit 1
 }
 
-PROJECT=$(gcloud config get project)
-REPOSITORY=gcr.io/$PROJECT
-IMAGE=udmis
-
 cmd=$1
 shift || usage missing command
+repo=$1
+
+PROJECT=$(gcloud config get project)
+
+if [[ -z $repo ]]; then
+    REPOSITORY=gcr.io/$PROJECT
+else
+    REPOSITORY=$repo
+fi
+
+IMAGE=udmis
+
 
 current_user=$USER@$HOSTNAME
 current_time=`date --utc --iso=seconds`


### PR DESCRIPTION
We need to be able to push to artifacts registries, as gcr.io is getting deprecated in 2024