### PR TITLE
Fix periodic_scan sequence

### DIFF
--- a/etc/sequencer_report.md.template
+++ b/etc/sequencer_report.md.template
@@ -6,7 +6,7 @@
 
 ## Device Identification
 
-| Device | AHU-1 |
+| Device | {{report.device_id}} |
 |---|---|
 | Site |  |
 | Make | {{report.device_make}} |

--- a/pubber/src/main/java/daq/pubber/Pubber.java
+++ b/pubber/src/main/java/daq/pubber/Pubber.java
@@ -1228,6 +1228,7 @@ public class Pubber {
     entry.detail = stackTraceString(e);
     entry.category = category;
     entry.level = Level.ERROR.value();
+    entry.timestamp = getCurrentTimestamp();
     return entry;
   }
 

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/BlobsetSequences.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/BlobsetSequences.java
@@ -1,6 +1,6 @@
 package com.google.daq.mqtt.sequencer.sequences;
 
-import static com.google.daq.mqtt.util.TimePeriodConstants.TWO_MINUTES_MS;
+import static com.google.daq.mqtt.util.TimePeriodConstants.THREE_MINUTES_MS;
 import static com.google.udmi.util.GeneralUtils.encodeBase64;
 import static com.google.udmi.util.GeneralUtils.sha256;
 import static com.google.udmi.util.JsonUtil.stringify;
@@ -190,7 +190,7 @@ public class BlobsetSequences extends SequenceBase {
     check_endpoint_connection_success(true);
   }
 
-  @Test(timeout = TWO_MINUTES_MS)
+  @Test(timeout = THREE_MINUTES_MS)
   @Feature(stage = ALPHA, bucket = ENDPOINT)
   public void endpoint_failure_and_restart() {
     setDeviceConfigEndpointBlob(BOGUS_ENDPOINT_HOSTNAME, registryId, false);

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/DiscoverySequences.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/DiscoverySequences.java
@@ -245,9 +245,14 @@ public class DiscoverySequences extends SequenceBase {
         families.stream().noneMatch(familyScanComplete(finishTime)));
     List<DiscoveryEvent> receivedEvents = popReceivedEvents(DiscoveryEvent.class);
     checkEnumeration(receivedEvents, shouldEnumerate);
-    int expected = SCAN_ITERATIONS * families.size();
-    int received = receivedEvents.size();
-    assertTrue("number responses received", received >= expected && received <= expected + 1);
+    Set<String> eventFamilies = receivedEvents.stream()
+        .flatMap(event -> event.families.keySet().stream())
+        .collect(Collectors.toSet());
+    assertTrue("all requested families present", eventFamilies.containsAll(families));
+    Map<String, List<DiscoveryEvent>> receivedEventsGrouped = receivedEvents.stream()
+        .collect(Collectors.groupingBy(e -> e.scan_family + "." + e.scan_addr));
+    assertTrue("scan iteration",
+        receivedEventsGrouped.values().stream().allMatch(list -> list.size() == SCAN_ITERATIONS));
   }
 
   private void initializeDiscovery() {

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/LocalnetSequences.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/LocalnetSequences.java
@@ -4,8 +4,6 @@ import static java.lang.String.format;
 
 import com.google.daq.mqtt.sequencer.SequenceBase;
 import org.junit.Test;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Validate localnet related functionality.
@@ -13,17 +11,13 @@ import java.util.stream.Collectors;
 public class LocalnetSequences extends SequenceBase {
 
   private void familyAddr(String family) {
-    Set<String> expectedFamilies = deviceMetadata.localnet.families.keySet().stream()
-        .filter(f -> f.contains(family)).collect(Collectors.toSet());
-    if (expectedFamilies.isEmpty()) {
-        skipTest(format("No %s address defined in metadata", family));
-    }
-    expectedFamilies.forEach(expectedFamily -> {
-        String expected = catchToNull(() -> deviceMetadata.localnet.families.get(expectedFamily).addr);
-        untilTrue("localnet families available", () -> deviceState.localnet.families.size() > 0);
-        String actual = catchToNull(() -> deviceState.localnet.families.get(expectedFamily).addr);
-        checkThat(format("device family %s address matches", expectedFamily), () -> expected.equals(actual));
-    });
+    String expected = ifNullSkipTest(
+        catchToNull(() -> deviceMetadata.localnet.families.get(family).addr),
+        format("No %s address defined in metadata", family));
+    untilTrue("localnet families available", () -> deviceState.localnet.families.size() > 0);
+    String actual = catchToNull(() -> deviceState.localnet.families.get(family).addr);
+    checkThat(format("device family %s address matches", family),
+        () -> expected.equals(actual));
   }
 
   @Test


### PR DESCRIPTION
~Update sequencer expectation when device supports multiple discovery/localnet families~

~- family_ether_addr~
~- family_ipv4_addr~
~- family_ipv6_addr~
- periodic_scan

