### PR TITLE
Change UDMIS to only replace timestamps and versions in configs

### DIFF
--- a/udmis/src/main/java/com/google/bos/udmi/service/core/ProcessorBase.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/core/ProcessorBase.java
@@ -311,8 +311,8 @@ public abstract class ProcessorBase extends ContainerBase implements SimpleHandl
     }
 
     String updateTimestamp = isoConvert();
-    payload.put(TIMESTAMP_KEY, updateTimestamp);
-    payload.put(VERSION_KEY, UDMI_VERSION);
+    payload.replace(TIMESTAMP_KEY, updateTimestamp);
+    payload.replace(VERSION_KEY, UDMI_VERSION);
 
     augmentPayload(payload, attributes.transactionId, previous.getKey());
     mungeConfigDebug(attributes, updateTimestamp, reason);


### PR DESCRIPTION
To avoid conflict with static configs 