### PR TITLE
Revert to put not replace

### DIFF
--- a/udmis/src/main/java/com/google/bos/udmi/service/core/ProcessorBase.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/core/ProcessorBase.java
@@ -318,8 +318,8 @@ public abstract class ProcessorBase extends ContainerBase implements SimpleHandl
     }
 
     String updateTimestamp = isoConvert();
-    payload.replace(TIMESTAMP_KEY, updateTimestamp);
-    payload.replace(VERSION_KEY, UDMI_VERSION);
+    payload.put(TIMESTAMP_KEY, updateTimestamp);
+    payload.put(VERSION_KEY, UDMI_VERSION);
 
     augmentPayload(payload, attributes.transactionId, previous.getKey());
     mungeConfigDebug(attributes, updateTimestamp, reason);


### PR DESCRIPTION
This fixes the common case (CI build) -- not sure how it crept in because it consistently fails (we should have a think about our dev/CI workflow)... not sure it won't break some non-tested use case out there.
