### PR TITLE
Publish validation events when running as validator with reflector

### DIFF
--- a/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
+++ b/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
@@ -479,6 +479,7 @@ public class Validator {
     outputLogger.info("Loading reflector key file from " + keyFile);
     config.key_file = keyFile;
     client = new IotReflectorClient(config, TOOLS_FUNCTIONS_VERSION);
+    dataSinks.add(client);
   }
 
   void messageLoop() {


### PR DESCRIPTION
These were not published because the reflect client was not a data sink for validation events:


```java
private void sendValidationMessage(String deviceId, Object message, String topic) {
    try {
      String messageString = OBJECT_MAPPER.writeValueAsString(message);
      dataSinks.forEach(sink -> sink.publish(deviceId, topic, messageString));
    } catch (Exception e) {
      throw new RuntimeException("While sending validation event for " + deviceId, e);
    }
  }
```