### PR TITLE
Need newer versions of pubsub to work with this version of protobuf

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -12,10 +12,10 @@ google-api-python-client==2.37.0
 google-auth==2.14.1
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.4.6
-google-cloud-pubsub==2.12.1
+google-cloud-pubsub==2.25.2
 google-cloud-trace==1.13.5
 googleapis-common-protos==1.65.0
-grpc-google-iam-v1==0.12.3
+grpc-google-iam-v1==0.13.1
 grpcio==1.65.1
 grpcio-status==1.65.1
 htmlmin==0.1.12


### PR DESCRIPTION
Without these changes, mirror.py fails with:

```
Traceback (most recent call last):
  File "/home/john/workspace/udmi/misc/gcloud_pubsub_mirror/mirror.py", line 16, in <module>
    from google.cloud import pubsub_v1
  File "/home/john/.pyenv/versions/3.11.9/envs/udmi/lib/python3.11/site-packages/google/cloud/pubsub_v1/__init__.py", line 17, in <module>
    from google.cloud.pubsub_v1 import types
  File "/home/john/.pyenv/versions/3.11.9/envs/udmi/lib/python3.11/site-packages/google/cloud/pubsub_v1/types.py", line 28, in <module>
    from google.iam.v1 import iam_policy_pb2  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/john/.pyenv/versions/3.11.9/envs/udmi/lib/python3.11/site-packages/google/iam/v1/iam_policy_pb2.py", line 16, in <module>
    from google.iam.v1 import options_pb2 as google_dot_iam_dot_v1_dot_options__pb2
  File "/home/john/.pyenv/versions/3.11.9/envs/udmi/lib/python3.11/site-packages/google/iam/v1/options_pb2.py", line 38, in <module>
    _descriptor.FieldDescriptor(
  File "/home/john/.pyenv/versions/3.11.9/envs/udmi/lib/python3.11/site-packages/google/protobuf/descriptor.py", line 621, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```