### PR TITLE
Upgrade pyOpenSSL for discoveryNode

### DIFF
--- a/misc/discoverynode/testing/docker/bacnet_device/requirements.txt
+++ b/misc/discoverynode/testing/docker/bacnet_device/requirements.txt
@@ -15,7 +15,7 @@ pluggy==1.5.0
 prometheus_client==0.20.0
 pycparser==2.22
 PyJWT==2.9.0
-pyOpenSSL==24.2.1
+pyOpenSSL==25.0.0
 pytest==8.3.2
 python-dateutil==2.9.0.post0
 pytz==2024.1


### PR DESCRIPTION
dependabot has upgraded cryptography to version 44.0.1
This is now causing conflicts and leading to failure of the discovery tests job:

```
1.649 The conflict is caused by:
1.649     The user requested cryptography==44.0.1
1.649     pyopenssl 24.2.1 depends on cryptography<44 and >=41.0.5
```