### PR TITLE
Fix some bugs in BAMBI & improve PR reviewer experience

### DIFF
--- a/common/src/main/java/com/google/udmi/util/JsonUtil.java
+++ b/common/src/main/java/com/google/udmi/util/JsonUtil.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.udmi.util.GeneralUtils.OBJECT_MAPPER_STRICT;
 import static com.google.udmi.util.GeneralUtils.fromJsonString;
 import static com.google.udmi.util.GeneralUtils.ifNotNullGet;
+import static com.google.udmi.util.GeneralUtils.isNotEmpty;
 import static com.google.udmi.util.GeneralUtils.toJsonString;
 import static java.util.Objects.requireNonNull;
 
@@ -511,6 +512,10 @@ public abstract class JsonUtil {
   @SuppressWarnings("unchecked")
   private static void flatten(Map<String, Object> currentMap, String currentKey,
       Map<String, Object> flattenedMap, String separator) {
+    if (currentMap.isEmpty() && isNotEmpty(currentKey)) {
+      flattenedMap.put(currentKey, currentMap);
+      return;
+    }
     for (Map.Entry<String, Object> entry : currentMap.entrySet()) {
       String key = entry.getKey();
       Object value = entry.getValue();
@@ -583,6 +588,12 @@ public abstract class JsonUtil {
 
     if ("null".equalsIgnoreCase(trimmedValue)) {
       return mapper.getNodeFactory().nullNode();
+    }
+    if ("{}".equals(trimmedValue)) {
+      return mapper.getNodeFactory().objectNode();
+    }
+    if ("[]".equals(trimmedValue)) {
+      return mapper.getNodeFactory().arrayNode();
     }
 
     try {

--- a/common/src/main/java/com/google/udmi/util/JsonUtil.java
+++ b/common/src/main/java/com/google/udmi/util/JsonUtil.java
@@ -19,11 +19,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.gson.internal.bind.util.ISO8601Utils;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.time.Instant;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -70,6 +70,18 @@ public abstract class JsonUtil {
   public static Map<String, Object> asMap(File input) {
     @SuppressWarnings("unchecked")
     Map<String, Object> map = loadFile(TreeMap.class, input);
+    return map;
+  }
+
+  /**
+   * Convert the json object to a LinkedHashMap object.
+   *
+   * @param input input file
+   * @return input as map object
+   */
+  public static Map<String, Object> asLinkedHashMap(File input) {
+    @SuppressWarnings("unchecked")
+    Map<String, Object> map = loadFile(LinkedHashMap.class, input);
     return map;
   }
 
@@ -491,7 +503,7 @@ public abstract class JsonUtil {
   }
 
   public static Map<String, Object> flattenNestedMap(Map<String, Object> map, String separator) {
-    Map<String, Object> flattenedMap = new TreeMap<>();
+    Map<String, Object> flattenedMap = new LinkedHashMap<>();
     flatten(map, "", flattenedMap, separator);
     return flattenedMap;
   }

--- a/common/src/main/java/com/google/udmi/util/JsonUtil.java
+++ b/common/src/main/java/com/google/udmi/util/JsonUtil.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -502,6 +504,24 @@ public abstract class JsonUtil {
       OBJECT_MAPPER.writeValue(file, theThing);
     } catch (Exception e) {
       throw new RuntimeException("While writing " + file.getAbsolutePath(), e);
+    }
+  }
+
+  /**
+   * Write json representation to a file.
+   * This method is added because the method `writeFile` does not print the array items on a newline.
+   *
+   * @param theThing object to write
+   * @param file     output file
+   */
+  public static void writeFileWithCustomIndentForArrays(Object theThing, File file) {
+    try {
+      DefaultPrettyPrinter.Indenter indenter = new DefaultIndenter("  ", DefaultIndenter.SYS_LF);
+      DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
+      printer.indentArraysWith(indenter);
+      OBJECT_MAPPER.writer(printer).writeValue(file, theThing);
+    } catch (Exception e) {
+      throw new RuntimeException("While writing with custom printer " + file.getAbsolutePath(), e);
     }
   }
 

--- a/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,7 @@ public class BambiSiteModelManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(BambiSiteModelManager.class);
   private final SpreadsheetManager spreadsheetManager;
   private final BambiSiteModel bambiSiteModel;
+  private static final Pattern LIST_TYPE_REGEX = Pattern.compile("\\[.*]");
 
   /**
    * Site Model Manager for a BAMBI spreadsheet.
@@ -94,7 +96,7 @@ public class BambiSiteModelManager {
    */
   public void writeSiteMetadata(Map<String, String> newSiteMetadata) {
     writeKeyValueTypeMetadata(BambiSheetTab.SITE_METADATA, bambiSiteModel.getSiteMetadataHeaders(),
-        newSiteMetadata);
+        handleListValues(newSiteMetadata));
   }
 
   /**
@@ -104,7 +106,7 @@ public class BambiSiteModelManager {
    */
   public void writeCloudIotConfig(Map<String, String> newCloudIotConfig) {
     writeKeyValueTypeMetadata(BambiSheetTab.CLOUD_IOT_CONFIG,
-        bambiSiteModel.getCloudIotConfigHeaders(), newCloudIotConfig);
+        bambiSiteModel.getCloudIotConfigHeaders(), handleListValues(newCloudIotConfig));
   }
 
   private void writeKeyValueTypeMetadata(BambiSheetTab sheet, List<String> headers,
@@ -296,6 +298,19 @@ public class BambiSiteModelManager {
       sheetData.add(List.of(entry.getKey(), entry.getValue()));
     }
     return sheetData;
+  }
+
+  private Map<String, String> handleListValues(Map<String, String> map) {
+    Map<String, String> output = new LinkedHashMap<>(map);
+    for (Entry<String, String> entry: output.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (value.matches(LIST_TYPE_REGEX.pattern())) {
+        value = value.substring(1, value.length()-1);
+      }
+      output.put(key, value);
+    }
+    return output;
   }
 
   // Helper structure for simple table configurations

--- a/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
@@ -1,6 +1,8 @@
 package com.google.bos.iot.core.bambi;
 
 
+import static com.google.bos.iot.core.bambi.Utils.removeBracketsFromListValues;
+
 import com.google.bos.iot.core.bambi.model.BambiSheetTab;
 import com.google.bos.iot.core.bambi.model.BambiSiteModel;
 import com.google.common.annotations.VisibleForTesting;
@@ -26,7 +28,6 @@ public class BambiSiteModelManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(BambiSiteModelManager.class);
   private final SpreadsheetManager spreadsheetManager;
   private final BambiSiteModel bambiSiteModel;
-  private static final Pattern LIST_TYPE_REGEX = Pattern.compile("\\[.*]");
 
   /**
    * Site Model Manager for a BAMBI spreadsheet.
@@ -96,7 +97,7 @@ public class BambiSiteModelManager {
    */
   public void writeSiteMetadata(Map<String, String> newSiteMetadata) {
     writeKeyValueTypeMetadata(BambiSheetTab.SITE_METADATA, bambiSiteModel.getSiteMetadataHeaders(),
-        handleListValues(newSiteMetadata));
+        removeBracketsFromListValues(newSiteMetadata));
   }
 
   /**
@@ -106,7 +107,7 @@ public class BambiSiteModelManager {
    */
   public void writeCloudIotConfig(Map<String, String> newCloudIotConfig) {
     writeKeyValueTypeMetadata(BambiSheetTab.CLOUD_IOT_CONFIG,
-        bambiSiteModel.getCloudIotConfigHeaders(), handleListValues(newCloudIotConfig));
+        bambiSiteModel.getCloudIotConfigHeaders(), removeBracketsFromListValues(newCloudIotConfig));
   }
 
   private void writeKeyValueTypeMetadata(BambiSheetTab sheet, List<String> headers,
@@ -298,19 +299,6 @@ public class BambiSiteModelManager {
       sheetData.add(List.of(entry.getKey(), entry.getValue()));
     }
     return sheetData;
-  }
-
-  private Map<String, String> handleListValues(Map<String, String> map) {
-    Map<String, String> output = new LinkedHashMap<>(map);
-    for (Entry<String, String> entry: output.entrySet()) {
-      String key = entry.getKey();
-      String value = entry.getValue();
-      if (value.matches(LIST_TYPE_REGEX.pattern())) {
-        value = value.substring(1, value.length()-1);
-      }
-      output.put(key, value);
-    }
-    return output;
   }
 
   // Helper structure for simple table configurations

--- a/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
@@ -256,18 +256,16 @@ public class BambiSiteModelManager {
         String value = rawEntry.getValue();
 
         String[] parts = combinedKey.split("\\.", 2);
+        String pointName = parts[0];
+        Map<String, String> pointMap = pointsForDevice.computeIfAbsent(pointName,
+            k -> new HashMap<>());
+        pointMap.put(BambiSiteModel.POINT_NAME, pointName);
         if (parts.length == 2) {
-          String pointName = parts[0];
           String propertyName = parts[1];
-
-          Map<String, String> pointMap = pointsForDevice.computeIfAbsent(pointName,
-              k -> new HashMap<>());
-
-          pointMap.put(BambiSiteModel.POINT_NAME, pointName);
           pointMap.put(propertyName, value);
         } else {
-          LOGGER.error(
-              "Warning: Skipping malformed point key: " + combinedKey + " for device " + deviceId);
+          LOGGER.warn(
+              "Warning: No properties for key: " + combinedKey + " for device " + deviceId);
         }
       }
 

--- a/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
@@ -15,7 +15,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
@@ -164,8 +164,8 @@ public class LocalSiteModelManager {
     }
   }
 
-  private Map<String, String> merge(Map<String, String> metadataOnDisk, Map<String, String> newMetadata,
-      boolean shouldUpdateTimestamp) {
+  private Map<String, String> merge(Map<String, String> metadataOnDisk,
+      Map<String, String> newMetadata, boolean shouldUpdateTimestamp) {
     metadataOnDisk = removeBracketsFromListValues(metadataOnDisk);
     for (Entry<String, String> entry : newMetadata.entrySet()) {
       String key = entry.getKey();

--- a/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
@@ -11,14 +11,13 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +37,11 @@ public class LocalSiteModelManager {
       "gateway.proxy_ids",
       "system.tags",
       "tags"
+  );
+
+  private final Set<Pattern> NON_NUMERIC_HEADERS_REGEX = Set.of(
+      Pattern.compile("pointset\\.points\\..*\\.ref"),
+      Pattern.compile("localnet\\.families\\..*\\.addr")
   );
 
   /**
@@ -70,7 +74,7 @@ public class LocalSiteModelManager {
   private void writeJsonToDisk(Map<String, String> flattenedData, String... paths) {
     URI filePath = Paths.get(pathToSiteModel, paths).toUri();
     LOGGER.info("writing data to file {}", filePath);
-    JsonNode jsonNode = nestFlattenedJson(flattenedData, "\\.");
+    JsonNode jsonNode = nestFlattenedJson(flattenedData, "\\.", NON_NUMERIC_HEADERS_REGEX);
     File file = new File(filePath);
     file.getParentFile().mkdirs();
     writeFile(jsonNode, new File(filePath));

--- a/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
@@ -55,7 +55,8 @@ public class LocalSiteModelManager {
     Path filePath = Paths.get(pathToSiteModel, path);
     LOGGER.info("fetching data from file " + filePath.toUri());
 
-    Map<String, Object> siteModelMap = asLinkedHashMap(new File(filePath.toUri()));
+    Map<String, Object> siteModelMap = catchToElse(
+        () -> asLinkedHashMap(new File(filePath.toUri())), new LinkedHashMap<>());
     return catchToElse(() -> flattenNestedMap(siteModelMap, ".").entrySet().stream()
         .collect(Collectors.toMap(
             Map.Entry::getKey,

--- a/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
@@ -11,11 +11,14 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +34,11 @@ public class LocalSiteModelManager {
   private static final String CLOUD_IOT_CONFIG_FILE = "cloud_iot_config.json";
   private static final String DEVICE_METADATA_FILE = "metadata.json";
   private final String pathToSiteModel;
+  private final Set<String> LIST_TYPE_HEADERS = Set.of(
+      "gateway.proxy_ids",
+      "system.tags",
+      "tags"
+  );
 
   /**
    * Site Model Manager for a site model stored on disk.
@@ -183,7 +191,7 @@ public class LocalSiteModelManager {
    *     another order-preserving map)
    */
   private void populateMap(String key, String newValue, Map<String, String> map) {
-    if ("gateway.proxy_ids".equals(key) || "system.tags".equals(key) || "tags".equals(key)) {
+    if (LIST_TYPE_HEADERS.contains(key)) {
       if (map.containsKey(key)) {
         Map<String, String> tempMap = new LinkedHashMap<>();
         String[] arrayValues = newValue.split(",");

--- a/services/src/main/java/com/google/bos/iot/core/bambi/Utils.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/Utils.java
@@ -30,11 +30,11 @@ public class Utils {
    */
   public static Map<String, String> removeBracketsFromListValues(Map<String, String> map) {
     Map<String, String> output = new LinkedHashMap<>(map);
-    for (Entry<String, String> entry: output.entrySet()) {
+    for (Entry<String, String> entry : output.entrySet()) {
       String key = entry.getKey();
       String value = entry.getValue();
       if (LIST_TYPE_HEADERS.contains(key) && value.matches(LIST_TYPE_REGEX.pattern())) {
-        value = value.substring(1, value.length()-1);
+        value = value.substring(1, value.length() - 1);
       }
       output.put(key, value);
     }
@@ -48,7 +48,7 @@ public class Utils {
    */
   public static Map<String, String> handleArraysInMap(Map<String, String> metadataMap) {
     Map<String, String> result = new LinkedHashMap<>();
-    for (Map.Entry<String, String> entry: metadataMap.entrySet()) {
+    for (Map.Entry<String, String> entry : metadataMap.entrySet()) {
       String key = entry.getKey();
       String value = entry.getValue();
       if (LIST_TYPE_HEADERS.contains(key)) {

--- a/services/src/main/java/com/google/bos/iot/core/bambi/Utils.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/Utils.java
@@ -1,0 +1,66 @@
+package com.google.bos.iot.core.bambi;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Utils defined to handle how specific fields should be rendered on the UI and processed by
+ * the backend.
+ * TODO: In the next phase, this should be controlled by a "Presentation Layer".
+ */
+public class Utils {
+
+  public static final Pattern LIST_TYPE_REGEX = Pattern.compile("\\[.*]");
+  public static final Set<String> LIST_TYPE_HEADERS = Set.of(
+      "gateway.proxy_ids",
+      "system.tags",
+      "tags"
+  );
+  public static final Set<Pattern> NON_NUMERIC_HEADERS_REGEX = Set.of(
+      Pattern.compile("pointset\\.points\\..*\\.ref"),
+      Pattern.compile("localnet\\.families\\..*\\.addr")
+  );
+
+  /**
+   * Remove brackets from specific keys where values are lists to reflect on the UI as a
+   * comma-separated list without square brackets.
+   */
+  public static Map<String, String> removeBracketsFromListValues(Map<String, String> map) {
+    Map<String, String> output = new LinkedHashMap<>(map);
+    for (Entry<String, String> entry: output.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (LIST_TYPE_HEADERS.contains(key) && value.matches(LIST_TYPE_REGEX.pattern())) {
+        value = value.substring(1, value.length()-1);
+      }
+      output.put(key, value);
+    }
+    return output;
+  }
+
+
+  /**
+   * Populates the map, expanding comma-separated values for specific keys
+   * while preserving the order of elements.
+   */
+  public static Map<String, String> handleArraysInMap(Map<String, String> metadataMap) {
+    Map<String, String> result = new LinkedHashMap<>();
+    for (Map.Entry<String, String> entry: metadataMap.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (LIST_TYPE_HEADERS.contains(key)) {
+        String[] arrayValues = value.split(",");
+        for (int i = 0; i < arrayValues.length; i++) {
+          result.put(key + "." + i, arrayValues[i].trim());
+        }
+      } else {
+        result.put(key, value);
+      }
+    }
+    return result;
+  }
+
+}

--- a/services/src/test/java/com/google/bos/iot/core/bambi/BambiSiteModelManagerTest.java
+++ b/services/src/test/java/com/google/bos/iot/core/bambi/BambiSiteModelManagerTest.java
@@ -370,7 +370,7 @@ public class BambiSiteModelManagerTest {
     Map<String, Map<String, String>> deviceToMetadataMap = new HashMap<>();
     Map<String, String> dev1Meta = new HashMap<>();
     dev1Meta.put("pointset.points.temp.units", "C");
-    dev1Meta.put("pointset.points.malformedkeyonly", "some_value");
+    dev1Meta.put("pointset.points.keyonly", "some_value");
     deviceToMetadataMap.put("dev1", dev1Meta);
 
     bambiSiteModelManager.writeDevicesMetadata(deviceToMetadataMap);
@@ -378,14 +378,20 @@ public class BambiSiteModelManagerTest {
     verify(mockSpreadsheetManager).writeToRange(
         eq(BambiSheetTab.POINTS.getName()), sheetDataCaptor.capture());
     List<List<Object>> pointsData = sheetDataCaptor.getValue();
-    assertEquals(2, pointsData.size()); // Header + 1 valid point
+    assertEquals(3, pointsData.size()); // Header + 1 valid point + 1 point with no properties
     boolean foundTempPoint = false;
+    boolean foundKeyOnlyPoint = false;
     for (int i = 1; i < pointsData.size(); i++) {
       if ("temp".equals(pointsData.get(i).get(1))) {
         assertEquals(Arrays.asList("dev1_template", "temp", "C", ""), pointsData.get(i));
         foundTempPoint = true;
       }
+      if ("keyonly".equals(pointsData.get(i).get(1))) {
+        assertEquals(Arrays.asList("dev1_template", "keyonly", "", ""), pointsData.get(i));
+        foundKeyOnlyPoint = true;
+      }
     }
     assertTrue("Valid temp point not found", foundTempPoint);
+    assertTrue("Key only point not found", foundKeyOnlyPoint);
   }
 }


### PR DESCRIPTION
* Preserve order of keys in the file on disk while merge to reduce number of changes in diff.
* Update timestamp when a device property changes. 
* Fix for the reported bugs: 
  - Site metadata tags get imported with square brackets when using the BAMBI add-on. Brackets should be removed.
  - Empty discovery block should be retained, currently it gets removed if empty.
  - testing.targets.invalid.target_value changes from array to string. Handle to retain array.
  - Point ref gets changed from string to integer, this could potentially break the config. It should not be auto-casted to a number
  - Handle exception for read from invalid json file

