### PR TITLE
Enable pointset replacement & fix a parsing error

### DIFF
--- a/common/src/main/java/com/google/udmi/util/JsonUtil.java
+++ b/common/src/main/java/com/google/udmi/util/JsonUtil.java
@@ -624,6 +624,12 @@ public abstract class JsonUtil {
       return mapper.getNodeFactory().arrayNode();
     }
 
+    // If the string contains any letters (and isn't "true" or "false"), treat it as a text node.
+    if (trimmedValue.matches(".*[a-zA-Z].*")) {
+      return mapper.getNodeFactory().textNode(value);
+    }
+
+    // Attempt to parse as a number
     try {
       int intValue = Integer.parseInt(trimmedValue);
       return mapper.getNodeFactory().numberNode(intValue);
@@ -636,6 +642,8 @@ public abstract class JsonUtil {
           double doubleValue = Double.parseDouble(trimmedValue);
           return mapper.getNodeFactory().numberNode(doubleValue);
         } catch (NumberFormatException e3) {
+          // Handle purely numeric-looking strings that still fail parsing
+          // (e.g., "1.2.3") and fall back to text.
           return mapper.getNodeFactory().textNode(value);
         }
       }

--- a/services/src/main/java/com/google/bos/iot/core/bambi/BambiService.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/BambiService.java
@@ -196,7 +196,7 @@ public class BambiService extends AbstractPollingService {
         + spreadsheetId)) {
       throw new RuntimeException("Unable to commit and push changes to branch " + exportBranch);
     }
-    LOGGER.info("Commit URL: {} ", repository.getCommitUrl(exportBranch));
+    LOGGER.info("Commit URL: {}\n", repository.getCommitUrl(exportBranch));
     LOGGER.info("Export operation complete.");
   }
 

--- a/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/BambiSiteModelManager.java
@@ -1,6 +1,7 @@
 package com.google.bos.iot.core.bambi;
 
 
+import static com.google.bos.iot.core.bambi.Utils.makeEmptyValuesExplicit;
 import static com.google.bos.iot.core.bambi.Utils.removeBracketsFromListValues;
 
 import com.google.bos.iot.core.bambi.model.BambiSheetTab;
@@ -112,6 +113,7 @@ public class BambiSiteModelManager {
   private void writeKeyValueTypeMetadata(BambiSheetTab sheet, List<String> headers,
       Map<String, String> data) {
     LOGGER.info("writing to sheet " + sheet.getName());
+    makeEmptyValuesExplicit(data);
     Map<String, String> newData = new LinkedHashMap<>();
     for (String header : headers) {
       newData.put(header, data.getOrDefault(header, ""));
@@ -141,6 +143,9 @@ public class BambiSiteModelManager {
         new SheetConfig(BambiSheetTab.LOCALNET, bambiSiteModel.getLocalnetDataHeaders())
     );
 
+    for (Map<String, String> value : deviceToMetadataMap.values()) {
+      makeEmptyValuesExplicit(value);
+    }
     for (SheetConfig config : simpleTableConfigs) {
       List<List<Object>> sheetData = processSimpleTableData(
           deviceToMetadataMap, config.headers(), config.sheet().getName() + "."
@@ -186,6 +191,7 @@ public class BambiSiteModelManager {
               e -> e.getKey().substring(keyPrefix.length()),
               Entry::getValue
           ));
+      makeEmptyValuesExplicit(relevantMetadata);
 
       sheetData.add(buildDataRow(deviceId, headers, relevantMetadata));
     }

--- a/services/src/main/java/com/google/bos/iot/core/bambi/Utils.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/Utils.java
@@ -23,6 +23,10 @@ public class Utils {
       Pattern.compile("pointset\\.points\\..*\\.ref"),
       Pattern.compile("localnet\\.families\\..*\\.addr")
   );
+  public static final Pattern POINTS_KEY_REGEX = Pattern.compile("pointset\\.points\\..*");
+  public static final String EMPTY_STRING = "\"\"";
+  public static final String EMPTY_MARKER = "__EMPTY__";
+  public static final String DELETE_MARKER = "__DELETE__";
 
   /**
    * Remove brackets from specific keys where values are lists to reflect on the UI as a
@@ -61,6 +65,36 @@ public class Utils {
       }
     }
     return result;
+  }
+
+  /**
+   * Make any empty value from dataFromDisk explicit so that it shows up in BAMBI as the
+   * empty string "" instead of an empty cell. This will enable both the user and BambiService
+   * to distinguish between a set empty value vs an unset value.
+   *
+   * @param dataFromDisk key-value data from disk
+   */
+  public static void makeEmptyValuesExplicit(Map<String, String> dataFromDisk) {
+    for (Entry<String, String> entry : dataFromDisk.entrySet()) {
+      if (entry.getValue().isEmpty()) {
+        dataFromDisk.put(entry.getKey(), EMPTY_STRING);
+      }
+    }
+  }
+
+  /**
+   * If a user wants a field to be empty, they can specify that in BAMBI by populating the cell
+   * with the empty string - "". For merging dataFromBambi with the data on disk, replace it
+   * with a special marker.
+   *
+   * @param dataFromBambi key-value data received from BAMBI
+   */
+  public static void handleExplicitlyEmptyValues(Map<String, String> dataFromBambi) {
+    for (Entry<String, String> entry : dataFromBambi.entrySet()) {
+      if (entry.getValue() != null && entry.getValue().equals(EMPTY_STRING)) {
+        dataFromBambi.put(entry.getKey(), EMPTY_MARKER);
+      }
+    }
   }
 
 }


### PR DESCRIPTION
- Enable pointset replacement instead of merge for easier renaming from the BAMBI Sheet
- Make empty strings explicit in the sheet, so a cell set with an empty string is populated with "" to distinguish from an unset cell
- Fix a parsing error (zone: "15F" was being parsed as "15.0" which is now fixed)