### PR TITLE
Remove whitespace before colon for files augmented through BAMBI

### DIFF
--- a/common/src/main/java/com/google/udmi/util/JsonUtil.java
+++ b/common/src/main/java/com/google/udmi/util/JsonUtil.java
@@ -525,6 +525,22 @@ public abstract class JsonUtil {
     }
   }
 
+  /**
+   * Writes a JSON representation to a file using the custom ProperPrinter
+   * to ensure correct colon spacing (e.g., "key": "value") and array item indentation.
+   *
+   * @param theThing object to write
+   * @param file     output file
+   */
+  public static void writeFormattedFile(Object theThing, File file) {
+    try {
+      ProperPrinter printer = new ProperPrinter(ProperPrinter.OutputFormat.VERBOSE);
+      OBJECT_MAPPER.writer(printer).writeValue(file, theThing);
+    } catch (Exception e) {
+      throw new RuntimeException("While writing formatted file " + file.getAbsolutePath(), e);
+    }
+  }
+
   public static Map<String, Object> flattenNestedMap(Map<String, Object> map, String separator) {
     Map<String, Object> flattenedMap = new LinkedHashMap<>();
     flatten(map, "", flattenedMap, separator);

--- a/common/src/main/java/com/google/udmi/util/JsonUtil.java
+++ b/common/src/main/java/com/google/udmi/util/JsonUtil.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.gson.internal.bind.util.ISO8601Utils;
+import com.google.udmi.util.ProperPrinter.OutputFormat;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -534,7 +535,7 @@ public abstract class JsonUtil {
    */
   public static void writeFormattedFile(Object theThing, File file) {
     try {
-      ProperPrinter printer = new ProperPrinter(ProperPrinter.OutputFormat.VERBOSE);
+      ProperPrinter printer = new ProperPrinter(OutputFormat.VERBOSE_ARRAY_ON_NEW_LINE);
       OBJECT_MAPPER.writer(printer).writeValue(file, theThing);
     } catch (Exception e) {
       throw new RuntimeException("While writing formatted file " + file.getAbsolutePath(), e);

--- a/common/src/main/java/com/google/udmi/util/ProperPrinter.java
+++ b/common/src/main/java/com/google/udmi/util/ProperPrinter.java
@@ -21,14 +21,20 @@ class ProperPrinter extends DefaultPrettyPrinter {
     super();
     this.indent = indent;
     isCompressed = indent == COMPRESSED;
-    if (isCompressed) {
-      Indenter indenter = new DefaultIndenter("", "");
-      indentObjectsWith(indenter);
-      indentArraysWith(indenter);
-    } else {
-      // Print each array element on a new line
-      Indenter arrayIndenter = new DefaultIndenter("  ", DefaultIndenter.SYS_LF);
-      indentArraysWith(arrayIndenter);
+
+    switch (indent) {
+      case COMPRESSED -> {
+        Indenter indenter = new DefaultIndenter("", "");
+        indentObjectsWith(indenter);
+        indentArraysWith(indenter);
+      }
+      case VERBOSE_ARRAY_ON_NEW_LINE -> {
+        indentArraysWith(new DefaultIndenter("  ", DefaultIndenter.SYS_LF));
+      }
+      case VERBOSE -> {
+        // No action is needed. We rely on the default behavior from the
+        // superclass for standard pretty-printing.
+      }
     }
   }
 
@@ -36,6 +42,7 @@ class ProperPrinter extends DefaultPrettyPrinter {
   public void writeObjectFieldValueSeparator(JsonGenerator generator) throws IOException {
     generator.writeRaw(isCompressed ? ":" : ": ");
   }
+
   @Override
   public DefaultPrettyPrinter createInstance() {
     return new ProperPrinter(this.indent);
@@ -43,6 +50,7 @@ class ProperPrinter extends DefaultPrettyPrinter {
 
   enum OutputFormat {
     VERBOSE,
+    VERBOSE_ARRAY_ON_NEW_LINE,
     COMPRESSED
   }
 }

--- a/common/src/main/java/com/google/udmi/util/ProperPrinter.java
+++ b/common/src/main/java/com/google/udmi/util/ProperPrinter.java
@@ -14,21 +14,31 @@ class ProperPrinter extends DefaultPrettyPrinter {
   static final PrettyPrinter INDENT_PRINTER = new ProperPrinter(VERBOSE);
   static final PrettyPrinter NO_INDENT_PRINTER = new ProperPrinter(COMPRESSED);
 
+  private final OutputFormat indent;
   private final boolean isCompressed;
 
-  private ProperPrinter(OutputFormat indent) {
+  ProperPrinter(OutputFormat indent) {
     super();
+    this.indent = indent;
     isCompressed = indent == COMPRESSED;
     if (isCompressed) {
       Indenter indenter = new DefaultIndenter("", "");
       indentObjectsWith(indenter);
       indentArraysWith(indenter);
+    } else {
+      // Print each array element on a new line
+      Indenter arrayIndenter = new DefaultIndenter("  ", DefaultIndenter.SYS_LF);
+      indentArraysWith(arrayIndenter);
     }
   }
 
   @Override
   public void writeObjectFieldValueSeparator(JsonGenerator generator) throws IOException {
     generator.writeRaw(isCompressed ? ":" : ": ");
+  }
+  @Override
+  public DefaultPrettyPrinter createInstance() {
+    return new ProperPrinter(this.indent);
   }
 
   enum OutputFormat {

--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -30,7 +30,7 @@ iniconfig==2.0.0
 isort==5.11.3
 Jinja2==3.1.6
 json-schema-for-humans==1.3.4
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.11.0
 markdown2==2.5.0
 MarkupSafe==2.0.1
 marshmallow==3.18.0

--- a/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
@@ -12,7 +12,7 @@ import static com.google.udmi.util.JsonUtil.asLinkedHashMap;
 import static com.google.udmi.util.JsonUtil.flattenNestedMap;
 import static com.google.udmi.util.JsonUtil.isoConvert;
 import static com.google.udmi.util.JsonUtil.nestFlattenedJson;
-import static com.google.udmi.util.JsonUtil.writeFileWithCustomIndentForArrays;
+import static com.google.udmi.util.JsonUtil.writeFormattedFile;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
@@ -77,7 +77,7 @@ public class LocalSiteModelManager {
     JsonNode jsonNode = nestFlattenedJson(flattenedData, "\\.", NON_NUMERIC_HEADERS_REGEX);
     File file = new File(filePath);
     file.getParentFile().mkdirs();
-    writeFileWithCustomIndentForArrays(jsonNode, new File(filePath));
+    writeFormattedFile(jsonNode, new File(filePath));
   }
 
   public Map<String, String> getSiteMetadata() {


### PR DESCRIPTION
* Use ProperPrinter to remove whitespace added before a colon for files augmented using BAMBI
* Upgrade `lazy-object-proxy` because install is failing for older versions