### PR TITLE
Remove unknown template runtime exception

### DIFF
--- a/services/src/main/java/com/google/bos/iot/core/bambi/model/BambiSiteModel.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/model/BambiSiteModel.java
@@ -1,7 +1,8 @@
 package com.google.bos.iot.core.bambi.model;
 
+import static com.google.udmi.util.GeneralUtils.isNotEmpty;
+
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -169,30 +170,37 @@ public class BambiSiteModel {
   }
 
   private List<Map<String, String>> mergePointsWithPointset() {
-    List<Map<String, String>> mergedData = new ArrayList<>();
-    Map<String, Integer> templateNameToIndexMap = new HashMap<>();
-
-    for (int i = 0; i < pointsetData.size(); i++) {
-      mergedData.add(new LinkedHashMap<>(pointsetData.get(i)));
-      templateNameToIndexMap.put(pointsetData.get(i).get(POINTS_TEMPLATE_NAME), i);
+    Map<String, List<Map<String, String>>> pointsTemplates = new LinkedHashMap<>();
+    for (Map<String, String> row : pointsData) {
+      String templateName = row.get(POINTS_TEMPLATE_NAME);
+      if (isNotEmpty(templateName)) {
+        pointsTemplates.putIfAbsent(templateName, new ArrayList<>());
+        pointsTemplates.get(templateName).add(row);
+      } else {
+        throw new RuntimeException("Template name must not be empty!");
+      }
     }
 
-    for (Map<String, String> row : pointsData) {
-      String pointTemplateName = row.get(POINTS_TEMPLATE_NAME);
-      String pointName = row.get(POINT_NAME);
+    List<Map<String, String>> mergedData = new ArrayList<>();
+    for (Map<String, String> pointsetDatum : pointsetData) {
+      Map<String, String> pointsetRow = new LinkedHashMap<>(pointsetDatum);
+      String templateName = pointsetRow.get(POINTS_TEMPLATE_NAME);
 
-      int matchingIndex = templateNameToIndexMap.getOrDefault(pointTemplateName, -1);
-      if (matchingIndex == -1) {
-        throw new RuntimeException(
-            "points use a template name which is not defined in the pointset: "
-                + pointTemplateName);
+      if (isNotEmpty(templateName)) {
+        if (!pointsTemplates.containsKey(templateName)) {
+          throw new RuntimeException("Unknown points template " + templateName);
+        }
+
+        for (Map<String, String> pointRow : pointsTemplates.get(templateName)) {
+          String pointName = pointRow.get(POINT_NAME);
+          for (Entry<String, String> cell : pointRow.entrySet()) {
+            String header = cell.getKey();
+            String val = cell.getValue();
+            pointsetRow.put(BambiSheetTab.POINTS.getName() + "." + pointName + "." + header, val);
+          }
+        }
       }
-      for (Entry<String, String> cell : row.entrySet()) {
-        String header = cell.getKey();
-        mergedData.get(matchingIndex).put(
-            BambiSheetTab.POINTS.getName() + "." + pointName + "." + header,
-            cell.getValue());
-      }
+      mergedData.add(pointsetRow);
     }
 
     return mergedData;

--- a/services/src/main/java/com/google/bos/iot/core/bambi/model/BambiSiteModel.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/model/BambiSiteModel.java
@@ -187,11 +187,8 @@ public class BambiSiteModel {
       String templateName = pointsetRow.get(POINTS_TEMPLATE_NAME);
 
       if (isNotEmpty(templateName)) {
-        if (!pointsTemplates.containsKey(templateName)) {
-          throw new RuntimeException("Unknown points template " + templateName);
-        }
-
-        for (Map<String, String> pointRow : pointsTemplates.get(templateName)) {
+        for (Map<String, String> pointRow : pointsTemplates.getOrDefault(templateName,
+            new ArrayList<>())) {
           String pointName = pointRow.get(POINT_NAME);
           for (Entry<String, String> cell : pointRow.entrySet()) {
             String header = cell.getKey();

--- a/services/src/test/java/com/google/bos/iot/core/bambi/BambiSiteModelTest.java
+++ b/services/src/test/java/com/google/bos/iot/core/bambi/BambiSiteModelTest.java
@@ -311,28 +311,6 @@ public class BambiSiteModelTest {
   }
 
   @Test
-  public void mergePointsWithPointset_pointTemplateNotFound_throwsRuntimeException() {
-    List<List<Object>> pointsetSheet = createTableListFromArrays(
-        new Object[]{BambiSiteModel.DEVICE_ID, BambiSiteModel.POINTS_TEMPLATE_NAME},
-        new Object[]{"dev1", "tpl_A"} // Uses undefined tpl_A
-    );
-    List<List<Object>> pointsSheet = createTableListFromArrays(
-        new Object[]{BambiSiteModel.POINTS_TEMPLATE_NAME, BambiSiteModel.POINT_NAME},
-        new Object[]{"tpl_B", "temp1"}
-    );
-
-    try {
-      new BambiSiteModel(
-          emptySheet(), emptySheet(), headerOnlySheet("h"), headerOnlySheet("h"),
-          headerOnlySheet("h"), headerOnlySheet("h"), pointsetSheet, pointsSheet
-      );
-      fail("Expected RuntimeException was not thrown.");
-    } catch (RuntimeException e) {
-      assertTrue(e.getMessage().contains("Unknown points template tpl_A"));
-    }
-  }
-
-  @Test
   public void mergePointsWithPointset_emptyPointsData_mergesPointsetOnly() {
     List<List<Object>> pointsetSheet = createTableListFromArrays(
         new Object[]{BambiSiteModel.DEVICE_ID, BambiSiteModel.POINTS_TEMPLATE_NAME, "unit"},
@@ -373,21 +351,6 @@ public class BambiSiteModelTest {
     assertEquals("", dev1Meta.get(PREFIX_POINTSET + ".points.." + BambiSiteModel.POINT_NAME));
   }
 
-  @Test(expected = RuntimeException.class)
-  public void mergePointsWithPointset_pointsRowWithNullTemplateName_throwsException() {
-    List<List<Object>> pointsetSheet = createTableListFromArrays(
-        new Object[]{BambiSiteModel.DEVICE_ID, BambiSiteModel.POINTS_TEMPLATE_NAME},
-        new Object[]{"dev1", "tpl1"}
-    );
-    List<List<Object>> pointsSheetNullTemplateName = createTableListFromArrays(
-        new Object[]{BambiSiteModel.POINTS_TEMPLATE_NAME, BambiSiteModel.POINT_NAME},
-        new Object[]{null, "P1"} // Java null in template name cell
-    );
-    new BambiSiteModel(
-        emptySheet(), emptySheet(), headerOnlySheet("h"), headerOnlySheet("h"),
-        headerOnlySheet("h"), headerOnlySheet("h"), pointsetSheet, pointsSheetNullTemplateName
-    );
-  }
 
   @Test
   public void mergePointsWithPointset_pointsRowWithEmptyTemplateName_throwsException() {

--- a/services/src/test/java/com/google/bos/iot/core/bambi/BambiSiteModelTest.java
+++ b/services/src/test/java/com/google/bos/iot/core/bambi/BambiSiteModelTest.java
@@ -314,11 +314,11 @@ public class BambiSiteModelTest {
   public void mergePointsWithPointset_pointTemplateNotFound_throwsRuntimeException() {
     List<List<Object>> pointsetSheet = createTableListFromArrays(
         new Object[]{BambiSiteModel.DEVICE_ID, BambiSiteModel.POINTS_TEMPLATE_NAME},
-        new Object[]{"dev1", "tpl_A"}
+        new Object[]{"dev1", "tpl_A"} // Uses undefined tpl_A
     );
     List<List<Object>> pointsSheet = createTableListFromArrays(
         new Object[]{BambiSiteModel.POINTS_TEMPLATE_NAME, BambiSiteModel.POINT_NAME},
-        new Object[]{"tpl_B", "temp1"} // Uses undefined tpl_B
+        new Object[]{"tpl_B", "temp1"}
     );
 
     try {
@@ -328,8 +328,7 @@ public class BambiSiteModelTest {
       );
       fail("Expected RuntimeException was not thrown.");
     } catch (RuntimeException e) {
-      assertTrue(e.getMessage()
-          .contains("points use a template name which is not defined in the pointset: tpl_B"));
+      assertTrue(e.getMessage().contains("Unknown points template tpl_A"));
     }
   }
 
@@ -337,7 +336,7 @@ public class BambiSiteModelTest {
   public void mergePointsWithPointset_emptyPointsData_mergesPointsetOnly() {
     List<List<Object>> pointsetSheet = createTableListFromArrays(
         new Object[]{BambiSiteModel.DEVICE_ID, BambiSiteModel.POINTS_TEMPLATE_NAME, "unit"},
-        new Object[]{"dev1", "tpl_A", "Celsius"}
+        new Object[]{"dev1", "", "Celsius"}
     );
     List<List<Object>> pointsSheetEmpty = headerOnlySheet(BambiSiteModel.POINTS_TEMPLATE_NAME,
         BambiSiteModel.POINT_NAME);
@@ -351,27 +350,6 @@ public class BambiSiteModelTest {
     assertEquals("Celsius", dev1Meta.get(PREFIX_POINTSET + ".unit"));
     for (String key : dev1Meta.keySet()) {
       assertFalse("No points data should be present", key.startsWith(PREFIX_POINTSET + ".points."));
-    }
-  }
-
-  @Test
-  public void mergePointsWithPointset_emptyPointsetData_withPoints_throwsRuntimeException() {
-    List<List<Object>> pointsetSheetEmpty = headerOnlySheet(BambiSiteModel.DEVICE_ID,
-        BambiSiteModel.POINTS_TEMPLATE_NAME);
-    List<List<Object>> pointsSheet = createTableListFromArrays(
-        new Object[]{BambiSiteModel.POINTS_TEMPLATE_NAME, BambiSiteModel.POINT_NAME},
-        new Object[]{"tpl_A", "temp1"}
-    );
-
-    try {
-      new BambiSiteModel(
-          emptySheet(), emptySheet(), headerOnlySheet("h"), headerOnlySheet("h"),
-          headerOnlySheet("h"), headerOnlySheet("h"), pointsetSheetEmpty, pointsSheet
-      );
-      fail("Expected RuntimeException was not thrown.");
-    } catch (RuntimeException e) {
-      assertTrue(e.getMessage()
-          .contains("points use a template name which is not defined in the pointset: tpl_A"));
     }
   }
 
@@ -412,14 +390,14 @@ public class BambiSiteModelTest {
   }
 
   @Test
-  public void mergePointsWithPointset_pointsRowWithStringValueNullTemplateName_throwsException() {
+  public void mergePointsWithPointset_pointsRowWithEmptyTemplateName_throwsException() {
     List<List<Object>> pointsetSheet = createTableListFromArrays(
         new Object[]{BambiSiteModel.DEVICE_ID, BambiSiteModel.POINTS_TEMPLATE_NAME},
         new Object[]{"dev1", "tpl1"}
     );
     List<List<Object>> pointsSheetStringNullTemplateName = createTableListFromArrays(
         new Object[]{BambiSiteModel.POINTS_TEMPLATE_NAME, BambiSiteModel.POINT_NAME},
-        new Object[]{"null", "P1"} // String "null" as template name
+        new Object[]{"", "P1"} // Empty String as template name
     );
     try {
       new BambiSiteModel(
@@ -429,8 +407,7 @@ public class BambiSiteModelTest {
       );
       fail("Expected RuntimeException");
     } catch (RuntimeException e) {
-      assertTrue(e.getMessage()
-          .contains("points use a template name which is not defined in the pointset: null"));
+      assertTrue(e.getMessage().contains("Template name must not be empty!"));
     }
   }
 
@@ -443,7 +420,7 @@ public class BambiSiteModelTest {
         new Object[]{BambiSiteModel.DEVICE_ID, "cloud_prop"}, new Object[]{"dev1", "CloudVal"});
     List<List<Object>> pointsetSheet = createTableListFromArrays(
         new Object[]{BambiSiteModel.DEVICE_ID, BambiSiteModel.POINTS_TEMPLATE_NAME, "ps_prop"},
-        new Object[]{"dev1", "tpl", "PsVal"});
+        new Object[]{"dev1", "", "PsVal"});
     List<List<Object>> pointsSheet = headerOnlySheet(BambiSiteModel.POINTS_TEMPLATE_NAME,
         BambiSiteModel.POINT_NAME);
 


### PR DESCRIPTION
Template names are added by default even when a device has no points. Export fails with exception "Unknown template" in this case since no points are defined for the template added by default.