### PR TITLE
docs: Clarify username and password derivation for MQTT Auth

### DIFF
--- a/docs/specs/mqtt_client.md
+++ b/docs/specs/mqtt_client.md
@@ -7,3 +7,10 @@
 The client should implement exponential backoff in the event of a loss of connection to the broker
 up to a maximum interval period of 120 seconds between connection attempts, and then should continue
 connection attempts indefinitely.
+
+## Authentication
+
+When connecting to the MQTT broker using simple username/password authentication (e.g. for local testing or when JWTs are not being used), the credentials are derived as follows:
+
+*   **Username**: The username is formatted as the path to the device, e.g. `/r/{registry}/d/{device}`.
+*   **Password**: The password is the first 8 characters of the sha256sum of the private `pkcs8` file.


### PR DESCRIPTION
This change adds an Authentication section to `docs/specs/mqtt_client.md` to clearly explain how credentials are derived when using password-based MQTT authentication.

Specifically, it clarifies that:
1. The Username should be formatted as the path to the device (`/r/{registry}/d/{device}`).
2. The Password is derived as the first 8 characters of the sha256sum of the private `pkcs8` file.

---
*PR created automatically by Jules for task [4587270351733014064](https://jules.google.com/task/4587270351733014064) started by @grafnu*