### PR TITLE
docs: link testing.md appropriately

### DIFF
--- a/docs/specs/sequences/readme.md
+++ b/docs/specs/sequences/readme.md
@@ -5,6 +5,7 @@
 Sequences are defined device behavior which are formulated from a series of events or communication messages.
 They can be tested using the [`sequencer` tool](../../tools/sequencer.md). The
 [generated steps](generated.md) for each test detail exactly what the tool actually checks.
+See the [Testing](testing.md) guide for information on adding new sequencer tests.
 
 ## Functional Sequences
 


### PR DESCRIPTION
docs: link testing.md appropriately

Linked testing.md under the main sequencer overview instead of inside functional sequences since it's a guide on adding sequencer tests rather than a functional sequence itself.

---
*PR created automatically by Jules for task [13660760770957340931](https://jules.google.com/task/13660760770957340931) started by @grafnu*