### PR TITLE
Optimize writeErrors to only update when changed

### DIFF
--- a/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
@@ -651,9 +651,19 @@ class LocalDevice implements SiteDevice {
     ErrorTree errorTree = getErrorTree();
     File errorsFile = new File(outDir, DEVICE_ERRORS_MAP);
     if (errorTree != null) {
-      try (PrintStream printStream = new PrintStream(Files.newOutputStream(errorsFile.toPath()))) {
-        System.err.println("Updating errors " + errorsFile);
-        errorTree.write(printStream);
+      try {
+        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+        try (PrintStream printStream = new PrintStream(baos)) {
+          errorTree.write(printStream);
+        }
+        byte[] newContent = baos.toByteArray();
+        byte[] oldContent = errorsFile.exists() ? Files.readAllBytes(errorsFile.toPath()) : null;
+        if (!java.util.Arrays.equals(newContent, oldContent)) {
+          System.err.println("Updating errors " + errorsFile);
+          try (java.io.OutputStream outputStream = Files.newOutputStream(errorsFile.toPath())) {
+            outputStream.write(newContent);
+          }
+        }
       } catch (Exception e) {
         throw new RuntimeException("While writing " + errorsFile.getAbsolutePath(), e);
       }


### PR DESCRIPTION
In the registrar, `writeErrors()` now checks if the content for `errors.map` differs from what's already on disk before rewriting the file and emitting the "Updating errors..." log. This prevents redundant file modifications and console spam when running the registrar consecutively with unchanged output.

---
*PR created automatically by Jules for task [14237025600436243489](https://jules.google.com/task/14237025600436243489) started by @grafnu*