### PR TITLE
Fix spellcheck CI failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ clientlib/python/.udmi_persistence.json
 clientlib/python/*/rsa_private.crt
 clientlib/python/*/rsa_private.pem
 clientlib/python/*/.udmi_persistence.json
+wordlist.dic

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -14,10 +14,12 @@ backend
 backoff
 BACnet
 bacnet
+BACnetEngineeringUnits
 BAMBI
 bambi
 blobset
 BMS
+boolean
 BOS
 breakpoint
 buildingsiot
@@ -27,8 +29,10 @@ ClearBlade
 CLI
 CloudRun
 CoAP
+cognisant
 comms
 config
+contextualise
 coreutils
 CoV
 cron
@@ -48,14 +52,17 @@ downlink
 enablement
 encoding
 encodings
+enum
 env
 envs
 etag
 etags
 ETHMAC
 ethmac
+ETL
 evice
 faucetsdn
+FCU
 fieldbus
 gcloud
 GCP
@@ -92,6 +99,7 @@ JUnit
 JVM
 JWT
 keygen
+KNX
 kube
 kubectl
 Kubernetes
@@ -99,6 +107,7 @@ localhost
 localnet
 logentry
 loglevel
+LWT
 MacOS
 macos
 md
@@ -114,6 +123,7 @@ nterface
 OIDC
 Onboarding
 onboarding
+OPC
 OSS
 pagent
 parameterization
@@ -135,6 +145,7 @@ pubber
 PubSub
 pubsub
 QoS
+QUDT
 Readme
 Reconciler
 reconciler
@@ -146,11 +157,15 @@ runtime
 Schemas
 schemas
 SDK
+Serialisation
+serialise
+serialised
 setpoint
 sha
 sharding
 src
 Stackdriver
+standardised
 stateStatus
 subblock
 subblocks
@@ -171,6 +186,7 @@ transactional
 transpile
 transpiles
 txt
+UCUM
 UDMI
 udmi
 UDMI's
@@ -182,6 +198,7 @@ unconfigured
 underspecified
 uniqs
 UNK
+unopinionated
 unprocessable
 unwriteable
 uplink


### PR DESCRIPTION
Added several acronyms and domain-specific words related to telemetry and smart building protocols (such as `UCUM`, `BACnetEngineeringUnits`, `QUDT`, etc.) to `.wordlist.txt` to fix failures in the spellcheck CI action. Also added `wordlist.dic` to `.gitignore` to prevent generated dictionary files from being tracked.

---
*PR created automatically by Jules for task [1008587949355605568](https://jules.google.com/task/1008587949355605568) started by @jainrocks*