### PR TITLE
Consolidate Dependabot PRs

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -5,7 +5,7 @@ certifi==2024.7.4
 cffi==2.0.0
 charset-normalizer==2.0.11
 click==8.0.3
-cryptography==46.0.5
+cryptography==46.0.7
 dataclasses-json==0.6.7
 Deprecated==1.2.14
 dill==0.4.0
@@ -55,7 +55,7 @@ Pygments==2.20.0
 PyJWT==2.12.0
 pylint==4.0.5
 pyparsing==3.0.7
-pytest==8.3.2
+pytest==9.0.3
 pytest-xdist==3.7.0
 pytz==2021.3
 PyYAML==6.0.2

--- a/misc/discoverynode/src/requirements.txt
+++ b/misc/discoverynode/src/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==46.0.5
+cryptography==46.0.7
 aiosqlite==0.22.1
 BAC0==23.7.3
 bacpypes==0.18.7
@@ -10,7 +10,7 @@ paho-mqtt==2.1.0
 pluggy==1.6.0
 pygments==2.20.0
 pyjwt==2.11.0
-pytest==9.0.2
+pytest==9.0.3
 python-dotenv==1.2.1
 pytz==2025.2
 scapy==2.7.0

--- a/misc/discoverynode/src/udmi/discovery/ether.py
+++ b/misc/discoverynode/src/udmi/discovery/ether.py
@@ -140,7 +140,8 @@ class EtherDiscovery(discovery.DiscoveryController):
   def nmap_stop_discovery(self):
     logging.info("stopping")
     self.cancel_threads.set()
-    self.nmap_thread.join()
+    if self.nmap_thread and self.nmap_thread.is_alive():
+      self.nmap_thread.join()
 
   @discovery.catch_exceptions_to_state
   @discovery.main_task

--- a/misc/discoverynode/testing/docker/bacnet_device/requirements.txt
+++ b/misc/discoverynode/testing/docker/bacnet_device/requirements.txt
@@ -2,7 +2,7 @@ BAC0==23.7.3
 bacpypes==0.18.7
 cffi==2.0.0
 colorama==0.4.6
-cryptography==46.0.5
+cryptography==46.0.7
 et-xmlfile==1.1.0
 iniconfig==2.0.0
 numpy==2.0.1
@@ -16,7 +16,7 @@ prometheus_client==0.20.0
 pycparser==2.22
 PyJWT==2.9.0
 pyOpenSSL==26.0.0
-pytest==8.3.2
+pytest==9.0.3
 python-dateutil==2.9.0.post0
 pytz==2024.1
 scapy==2.5.0


### PR DESCRIPTION
Consolidated dependency bumps PR to update `pytest` (to 9.0.3) and `cryptography` (to 46.0.7) across the project. Also resolved an issue testing thread `join` logic in `misc/discoverynode/src/udmi/discovery/ether.py`.

---
*PR created automatically by Jules for task [18224631930562188979](https://jules.google.com/task/18224631930562188979) started by @khyatimahendru*