### PR TITLE
Update modbus spec with new params and examples

### DIFF
--- a/docs/specs/modbus.md
+++ b/docs/specs/modbus.md
@@ -33,16 +33,17 @@ UDMI supports reading Modbus points by specifying them via a `modbus://` URL sch
 Parameters passed in the query string define how to interpret the fetched register data:
 
 *   **`border`**: i.e., `MSB` (`Big-Endian`) or `LSB` (`Little-Endian`).
-*   **`type`**: i.e., `INT16`, `UINT32`, `BOOLEAN`, `ASCII`.
+*   **`type`**: i.e., `INT16`, `UINT32`, `FLOAT32`, `BOOLEAN`, `ASCII`.
 *   **`worder`**: i.e., `HWF` (`High-Word First`) or `LWF` (`Low-Word First`) (for 32-bit values).
 *   **`scale`**: i.e., `1.0`, `0.01`, `100.0` (scale factor).
+*   **`bit`**: Integer bit index.
 
 ### Network Parameters
 
 The `host` maps to a named network in the device's `model_localnet.json` (under the `networks` field). Each named network can define the following parameters for communication:
 
 *   **`baud`**: The baud rate.
-*   **`protocol`**: i.e., `RTU`, `TCP`.
+*   **`protocol`**: i.e., `RTU`, `TCP`, `ASCII`.
 *   **`parity`**: For serial `RTU`.
 *   **`data bits`**: For serial `RTU`.
 *   **`stop bits`**: For serial `RTU`.

--- a/docs/specs/modbus.md
+++ b/docs/specs/modbus.md
@@ -33,10 +33,10 @@ UDMI supports reading Modbus points by specifying them via a `modbus://` URL sch
 Parameters passed in the query string define how to interpret the fetched register data:
 
 *   **`border`**: i.e., `MSB` (`Big-Endian`) or `LSB` (`Little-Endian`).
-*   **`type`**: i.e., `INT16`, `UINT32`, `FLOAT32`, `BOOLEAN`, `ASCII`.
+*   **`type`**: e.g., `INT16`, `UINT32`, `FLOAT32`, `BOOLEAN`, `ASCII`.
 *   **`worder`**: i.e., `HWF` (`High-Word First`) or `LWF` (`Low-Word First`) (for 32-bit values).
-*   **`scale`**: i.e., `1.0`, `0.01`, `100.0` (scale factor).
-*   **`bit`**: Integer bit index.
+*   **`scale`**: e.g., `1.0`, `0.01`, `100.0` (scale factor).
+*   **`bit`**: e.g., `2` (Integer bit index).
 
 ### Network Parameters
 

--- a/validator/src/main/java/com/google/daq/mqtt/util/providers/ModbusFamilyProvider.java
+++ b/validator/src/main/java/com/google/daq/mqtt/util/providers/ModbusFamilyProvider.java
@@ -35,7 +35,7 @@ public class ModbusFamilyProvider implements FamilyProvider {
       ImmutableSet.of("1", "2", "3", "4", "5", "6", "15", "16");
 
   private static final Set<String> ALLOWED_PARAMS =
-      ImmutableSet.of("border", "type", "worder", "scale");
+      ImmutableSet.of("border", "type", "worder", "scale", "bit");
 
   @Override
   public String familyKey() {


### PR DESCRIPTION
Update the `modbus.md` spec with the following items:

* Appropriate type example for "Float32"
* Add a `bit` interpretation parameter (integer bit index)
* Add a `ASCII` value for the protocol enum

---
*PR created automatically by Jules for task [5253742198133533737](https://jules.google.com/task/5253742198133533737) started by @grafnu*