### PR TITLE
Add mosquitto logs to support bundle

### DIFF
--- a/bin/support
+++ b/bin/support
@@ -22,6 +22,10 @@ mkdir -p $OUT_DIR
 echo Copying cached config files to $OUT_DIR/
 cp $CONFIG_FILES $OUT_DIR/ || true
 
+echo Copying mosquitto logs to $OUT_DIR/
+sudo cp /var/log/mosquitto/mosquitto.log $OUT_DIR/ || true
+sudo chown $USER $OUT_DIR/mosquitto.log || true
+
 site_model=
 config_files=$(ls -t $OUT_DIR/*_config.json) || true
 for config in $config_files; do


### PR DESCRIPTION
Add mosquitto logs to support bundle

Modified the `bin/support` script to also include local mosquitto logs (`/var/log/mosquitto/mosquitto.log`) in the generated support archive if the file exists. This will make it easier to debug test failures related to MQTT traffic on the local test instances.

---
*PR created automatically by Jules for task [1993886326465635456](https://jules.google.com/task/1993886326465635456) started by @khyatimahendru*