### PR TITLE
fix: Resolve null thread reference in EtherDiscovery teardown

### DIFF
--- a/misc/discoverynode/src/udmi/discovery/ether.py
+++ b/misc/discoverynode/src/udmi/discovery/ether.py
@@ -140,7 +140,8 @@ class EtherDiscovery(discovery.DiscoveryController):
   def nmap_stop_discovery(self):
     logging.info("stopping")
     self.cancel_threads.set()
-    self.nmap_thread.join()
+    if self.nmap_thread and self.nmap_thread.is_alive():
+      self.nmap_thread.join()
 
   @discovery.catch_exceptions_to_state
   @discovery.main_task


### PR DESCRIPTION
Added a conditional check to ensure `self.nmap_thread` exists and is alive before invoking `.join()` during teardown in `nmap_stop_discovery`. This resolves an `AttributeError` that was causing `pytest` crashes when teardown ran on mocked or partially initialized test environments.