### PR TITLE
Fix events system upgrade

### DIFF
--- a/common/src/main/java/com/google/udmi/util/MessageUpgrader.java
+++ b/common/src/main/java/com/google/udmi/util/MessageUpgrader.java
@@ -289,6 +289,24 @@ public class MessageUpgrader {
     if (STATE_SCHEMA.equals(schemaName)) {
       upgradeTo_1_5_0_state();
     }
+    if (EVENTS_SYSTEM_SCHEMA.equals(schemaName)) {
+      upgradeTo_1_5_0_events_system();
+    }
+  }
+
+  private void upgradeTo_1_5_0_events_system() {
+    JsonNode logentries = message.get("logentries");
+    if (logentries != null && logentries.isArray()) {
+      for (JsonNode entry : logentries) {
+        if (entry.has("category")) {
+          String category = entry.get("category").asText();
+          if (category.startsWith("system.network")) {
+            String newCategory = category.replace("system.network", "localnet.network");
+            ((ObjectNode) entry).put("category", newCategory);
+          }
+        }
+      }
+    }
   }
 
   private void upgradeTo_1_5_0_state() {

--- a/common/src/test/java/com/google/udmi/util/MessageUpgraderTest.java
+++ b/common/src/test/java/com/google/udmi/util/MessageUpgraderTest.java
@@ -1,6 +1,8 @@
 package com.google.udmi.util;
 
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 import udmi.schema.State;
 
@@ -17,4 +19,26 @@ public class MessageUpgraderTest {
     stateMessage.version = BAD_VERSION;
     new MessageUpgrader("state", stateMessage);
   }
+
+  @Test
+  public void eventsSystemUpgrade() {
+    ObjectNode message = MessageUpgrader.NODE_FACTORY.objectNode();
+    message.put("version", "1.4.1");
+    ObjectNode entry1 = MessageUpgrader.NODE_FACTORY.objectNode();
+    entry1.put("category", "system.network.disconnect");
+    ObjectNode entry2 = MessageUpgrader.NODE_FACTORY.objectNode();
+    entry2.put("category", "system.network.connect");
+    ObjectNode entry3 = MessageUpgrader.NODE_FACTORY.objectNode();
+    entry3.put("category", "system.auth.login");
+    message.putArray("logentries").add(entry1).add(entry2).add(entry3);
+
+    MessageUpgrader upgrader = new MessageUpgrader("events_system", message);
+    JsonNode upgraded = (JsonNode) upgrader.upgrade();
+    
+    JsonNode logentries = upgraded.get("logentries");
+    org.junit.Assert.assertEquals("localnet.network.disconnect", logentries.get(0).get("category").asText());
+    org.junit.Assert.assertEquals("localnet.network.connect", logentries.get(1).get("category").asText());
+    org.junit.Assert.assertEquals("system.auth.login", logentries.get(2).get("category").asText());
+  }
+
 }

--- a/common/src/test/java/com/google/udmi/util/MessageUpgraderTest.java
+++ b/common/src/test/java/com/google/udmi/util/MessageUpgraderTest.java
@@ -1,5 +1,6 @@
 package com.google.udmi.util;
 
+import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -36,9 +37,9 @@ public class MessageUpgraderTest {
     JsonNode upgraded = (JsonNode) upgrader.upgrade();
     
     JsonNode logentries = upgraded.get("logentries");
-    org.junit.Assert.assertEquals("localnet.network.disconnect", logentries.get(0).get("category").asText());
-    org.junit.Assert.assertEquals("localnet.network.connect", logentries.get(1).get("category").asText());
-    org.junit.Assert.assertEquals("system.auth.login", logentries.get(2).get("category").asText());
+    assertEquals("localnet.network.disconnect", logentries.get(0).get("category").asText());
+    assertEquals("localnet.network.connect", logentries.get(1).get("category").asText());
+    assertEquals("system.auth.login", logentries.get(2).get("category").asText());
   }
 
 }


### PR DESCRIPTION
### The Problem

1. **Schema Evolution:** In older UDMI schemas (like `1.4.1` used by the EasyIO devices), network connection events were logged using the `system.network.*` category prefix (e.g., `system.network.disconnect` and `system.network.connect`). In version `1.5.0`, the schema was updated, and this category namespace was migrated to `localnet.network.*`.
2. **Validator Workflow:** When the UDMI Validator receives a payload from a device claiming an older version (e.g. `1.4.1`), it automatically tries to **upgrade** the message in memory to the latest standard before validating it against the newest schemas.
3. **The Missing Logic:** The `MessageUpgrader` component contained logic for upgrading `state` messages, but it completely lacked any upgrade logic for `events_system` messages. 
4. **The Failure:** As a result, when the `events_system` messages were checked against the 1.5.0 schema, the categories were still prefixed with `system.network.*`. The 1.5.0 schema validator correctly rejected them as unrecognized categories since it was strictly expecting `localnet.network.*`.

### The Solution

1. **Upgrading `events_system` Categories:** Added a new method `upgradeTo_1_5_0_events_system()` to the `MessageUpgrader` class. This method intercepts `events_system` messages as they are being upgraded to `1.5.0`.
2. **Category Replacement:** The code safely iterates over the `logentries` array inside the payload payload. For each log entry, if the `category` string begins with `system.network`, it replaces the prefix with `localnet.network` (e.g. translating `system.network.connect` to `localnet.network.connect`). 
3. **Testing:** Added a unit test (`eventsSystemUpgrade`) in `MessageUpgraderTest.java` to ensure this substitution behaves correctly and doesn't affect other valid categories like `system.auth.login`.
