### PR TITLE
Fix Cloud IoT reflector connection drops

### DIFF
--- a/validator/src/main/java/com/google/bos/iot/core/proxy/MqttPublisher.java
+++ b/validator/src/main/java/com/google/bos/iot/core/proxy/MqttPublisher.java
@@ -544,7 +544,9 @@ public class MqttPublisher implements MessagePublisher {
       subscribeToConfig(deviceId);
       subscribeToErrors(deviceId);
       subscribeToCommands(deviceId);
-      clientSubscribe(REFLECT_TOPIC, QOS_AT_LEAST_ONCE);
+      if (iotProvider == IotProvider.MQTT) {
+        clientSubscribe(REFLECT_TOPIC, QOS_AT_LEAST_ONCE);
+      }
       LOG.info(deviceId + " done with setup connection");
     } catch (Exception e) {
       throw new RuntimeException("While setting up new mqtt connection to " + deviceId, e);


### PR DESCRIPTION
### Problem
When running the registrar or connecting a reflector client against a Cloud IoT Core-style endpoint (like `gbos`), the proxy connection was immediately failing with an `EOFException`.

### Cause
The recent UUFI implementation changes introduced a global `/reflect` subscription in `MqttPublisher` to support Mosquitto environments. However, Cloud IoT endpoints strictly limit topics and will immediately disconnect clients that attempt to subscribe to invalid topics like `/reflect`.

### Fix
Modified `MqttPublisher.java` to conditionally subscribe to the `REFLECT_TOPIC` only when `iotProvider == IotProvider.MQTT`.