### PR TITLE
Add dev-test environment to CI workflow jobs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - '**'
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
   schedule:
     - cron: '0 13 * * *'
 
@@ -29,6 +29,8 @@ jobs:
           python-version: '3.13'
       - name: Checkout source
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: start and test local servers
         run: |
           bin/setup_base
@@ -64,6 +66,8 @@ jobs:
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Check Spelling
         uses: rojopolis/spellcheck-github-actions@0.35.0
         with:
@@ -80,6 +84,8 @@ jobs:
       TARGET_PROJECT: ${{ vars.TARGET_PROJECT || '//mqtt/localhost' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -131,6 +137,8 @@ jobs:
       UDMI_ALT_REGISTRY: ZZ-REDIRECT-NA
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -186,6 +194,8 @@ jobs:
       MATRIX_SHARD_INDEX: ${{ matrix.shard }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -241,6 +251,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -312,6 +324,8 @@ jobs:
       TARGET_PROJECT: //mqtt/localhost
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -351,6 +365,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
       - uses: actions/setup-java@v5
         with:
@@ -389,6 +404,8 @@ jobs:
       UDMI_ALT_REGISTRY: ZZ-REDIRECT-NA
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
@@ -426,6 +443,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
           fetch-tags: true
       - uses: actions/setup-java@v5
@@ -496,6 +514,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -75,6 +75,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: ${{ !cancelled() }}
+    environment: dev-test
     env:
       TARGET_PROJECT: ${{ vars.TARGET_PROJECT || '//mqtt/localhost' }}
     steps:
@@ -124,6 +125,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: automapping
+    environment: dev-test
     env:
       TARGET_PROJECT: ${{ vars.TARGET_PROJECT || '//mqtt/localhost' }}
       UDMI_ALT_REGISTRY: ZZ-REDIRECT-NA
@@ -175,6 +177,7 @@ jobs:
       fail-fast: false
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    environment: dev-test
     env:
       TARGET_PROJECT: ${{ vars.TARGET_PROJECT || '//mqtt/localhost' }}
       UDMI_ALT_REGISTRY: ZZ-REDIRECT-NA
@@ -341,6 +344,7 @@ jobs:
     name: Blob Updates
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    environment: dev-test
     env:
       TARGET_PROJECT: ${{ vars.TARGET_PROJECT || '//mqtt/localhost' }}
       UDMI_REGISTRY_SUFFIX: _BU
@@ -379,6 +383,7 @@ jobs:
     timeout-minutes: 5
     needs: [ baseline, sequencer, endpoint, runlocal, blobupdates ]
     if: ${{ !cancelled() }}
+    environment: dev-test
     env:
       TARGET_PROJECT: ${{ vars.TARGET_PROJECT || '//mqtt/localhost' }}
       UDMI_ALT_REGISTRY: ZZ-REDIRECT-NA


### PR DESCRIPTION
This change allows PRs from forks to safely access the TARGET_PROJECT variable via the dev-test environment. If the environment doesn't exist (e.g., on a fork), it gracefully falls back
to the default localhost testing environment.