### PR TITLE
Skip etcd prerun/postrun checks for cloud targets

### DIFF
--- a/bin/test_etcd_postrun
+++ b/bin/test_etcd_postrun
@@ -6,6 +6,17 @@ ROOT=$(dirname $0)/..
 
 source $ROOT/etc/shell_common.sh
 
+# Skip if not a mqtt run
+project_spec=${TARGET_PROJECT:-}
+if [[ -n $project_spec ]]; then
+    iot_provider=${project_spec%/*}
+    iot_provider=${iot_provider#//}
+    if [[ $iot_provider != mqtt ]]; then
+        echo "Target project provider is $iot_provider (not mqtt), skipping etcd check."
+        exit 0
+    fi
+fi
+
 # Print everything for debug
 $ROOT/udmis/bin/etcdctl get --prefix ""
 more sites/udmi_site_model/devices/AHU-1/* | cat

--- a/bin/test_etcd_prerun
+++ b/bin/test_etcd_prerun
@@ -5,4 +5,16 @@ ROOT=$(dirname $0)/..
 
 source $ROOT/etc/shell_common.sh
 
+# Skip if not a mqtt run
+project_spec=${TARGET_PROJECT:-}
+if [[ -n $project_spec ]]; then
+    iot_provider=${project_spec%/*}
+    iot_provider=${iot_provider#//}
+    if [[ $iot_provider != mqtt ]]; then
+        echo "Target project provider is $iot_provider (not mqtt), skipping etcd check."
+        exit 0
+    fi
+fi
+
 $ROOT/udmis/bin/etcdctl member list
+


### PR DESCRIPTION
Modified both `bin/test_etcd_prerun` and `bin/test_etcd_postrun` to check the TARGET_PROJECT environment variable. If the target project provider is not 'mqtt', the scripts will now exit early and successfully, preventing failures in cloud test runs where etcd is not started.