### PR TITLE
mqtt to pubsub bridge overhaul

### DIFF
--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -92,6 +92,9 @@ public class MqttToPubSubBridge {
   private final ThreadPoolExecutor executor;
   private volatile boolean tripped = false;
 
+  /**
+   * Initializes a new instance of the bridge, configuring the underlying executor.
+   */
   public MqttToPubSubBridge() {
     this.executor = new ThreadPoolExecutor(
         NUM_THREADS, NUM_THREADS,

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -88,7 +88,7 @@ public class MqttToPubSubBridge {
 
   private static final int MAX_QUEUE_SIZE = 99;
   private static final int NUM_THREADS = Runtime.getRuntime().availableProcessors() * 2;
-  
+
   private final ThreadPoolExecutor executor;
   private volatile boolean tripped = false;
 
@@ -101,6 +101,11 @@ public class MqttToPubSubBridge {
         new ThreadPoolExecutor.CallerRunsPolicy());
   }
 
+  /**
+   * Checks if the circuit breaker has been tripped.
+   *
+   * @return true if tripped, false otherwise
+   */
   public boolean isTripped() {
     return tripped;
   }
@@ -177,7 +182,7 @@ public class MqttToPubSubBridge {
       logger.error("gcp_project_id, pubsub_topic_id, and mqtt_client_id are required.");
       System.exit(1);
     }
-    
+
     Long sessionExpiryInterval = 0xFFFFFFFFL;
     if (mqttSessionExpiryInterval != null) {
       sessionExpiryInterval = Long.parseLong(mqttSessionExpiryInterval);
@@ -278,7 +283,8 @@ public class MqttToPubSubBridge {
     options.addOption(null, "gcp_project_id", true, "Google Cloud Project ID.");
     options.addOption(null, "pubsub_topic_id", true, "Google Cloud Pub/Sub topic ID.");
     options.addOption(null, "mqtt_client_id", true, "MQTT client ID.");
-    options.addOption(null, "mqtt_session_expiry_interval", true, "MQTT session expiry interval (seconds).");
+    options.addOption(null, "mqtt_session_expiry_interval", true,
+        "MQTT session expiry interval (seconds).");
     options.addOption(null, "mqtt_tls", false, "Enable TLS for MQTT connection.");
     options.addOption(null, "mqtt_ca_path", true, "Path to CA certificate for TLS.");
     options.addOption(null, "mqtt_username", true, "MQTT username for authentication.");
@@ -432,7 +438,8 @@ public class MqttToPubSubBridge {
                   }
 
                   ByteString data = ByteString.copyFrom(payload);
-                  PubsubMessage.Builder pubsubMessageBuilder = PubsubMessage.newBuilder().setData(data);
+                  PubsubMessage.Builder pubsubMessageBuilder =
+                      PubsubMessage.newBuilder().setData(data);
 
                   PubsubMessage pubsubMessage =
                       pubsubMessageBuilder.putAllAttributes(attributes).build();
@@ -452,7 +459,8 @@ public class MqttToPubSubBridge {
 
                     @Override
                     public void onFailure(Throwable t) {
-                      logger.warn("Error publishing to Pub/Sub, dropping ACK so broker can redeliver", t);
+                      logger.warn(
+                          "Error publishing to Pub/Sub, dropping ACK so broker can redeliver", t);
                     }
                   }, MoreExecutors.directExecutor());
 

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -1,7 +1,5 @@
 package com.google.bos.udmi.service.bridge;
 
-import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
@@ -31,11 +29,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.KeyManagerFactory;
@@ -212,7 +208,8 @@ public final class MqttToPubSubBridge {
       startCircuitBreaker(mqttClient, executor);
 
       // Set up MQTT Message Callback
-      setupBridge(mqttClient, publisher, mqttSubscriptionTopic, etcdProvider, sourceAttribute, sharedSubscription);
+      setupBridge(mqttClient, publisher, mqttSubscriptionTopic,
+          etcdProvider, sourceAttribute, sharedSubscription);
 
       // Keep the application running
       while (true) {
@@ -317,14 +314,19 @@ public final class MqttToPubSubBridge {
     setupBridge(mqttClient, publisher, mqttSubscriptionTopic, etcdProvider, sourceAttribute, null);
   }
 
+  /**
+   * Sets up the bridge between MQTT and Pub/Sub with a custom source attribute value.
+   */
   public static void setupBridge(IMqttClient mqttClient, Publisher publisher,
       String mqttSubscriptionTopic, EtcdDataProvider etcdProvider, String sourceAttribute,
       String sharedSubscription)
       throws MqttException {
-    
+
     final String actualSubscriptionTopic;
-    if (sharedSubscription != null && !sharedSubscription.isEmpty() && !mqttSubscriptionTopic.startsWith("$share/")) {
-      actualSubscriptionTopic = String.format("$share/%s/%s", sharedSubscription, mqttSubscriptionTopic);
+    if (sharedSubscription != null && !sharedSubscription.isEmpty()
+        && !mqttSubscriptionTopic.startsWith("$share/")) {
+      actualSubscriptionTopic = String.format("$share/%s/%s", sharedSubscription,
+          mqttSubscriptionTopic);
     } else {
       actualSubscriptionTopic = mqttSubscriptionTopic;
     }
@@ -365,8 +367,8 @@ public final class MqttToPubSubBridge {
               executor.submit(() -> {
                 try {
                   byte[] payload = message.getPayload();
-                  logger.debug(
-                      "MQTT Message Received - Topic: {}, Payload Length: {}", topic, payload.length);
+                  logger.debug("MQTT Message Received - Topic: {}, Payload Length: {}",
+                      topic, payload.length);
 
                   String parsedTopic = topic;
                   // Automatically strip the shared subscription prefix if present
@@ -430,8 +432,8 @@ public final class MqttToPubSubBridge {
                       break; // success
                     } catch (Exception e) {
                       // Note: Poison pills (e.g., consistently failing serialization) could
-                      // permanently block this thread since we retry indefinitely, but
-                      // schema validation happens earlier in the pipeline so it is not a concern here.
+                      // permanently block this thread since we retry indefinitely,
+                      // but schema validation happens earlier in the pipeline.
                       logger.warn("Error publishing to Pub/Sub, retrying in {} ms", backoff, e);
                       try {
                         Thread.sleep(backoff);
@@ -448,7 +450,7 @@ public final class MqttToPubSubBridge {
                 }
               });
             } catch (RejectedExecutionException e) {
-              logger.error("Execution rejected, queue is full! Dropping MQTT connection to mitigate stall.", e);
+              logger.error("Execution rejected, queue full! Dropping MQTT connection.", e);
               try {
                 mqttClient.disconnectForcibly();
               } catch (MqttException me) {
@@ -612,8 +614,9 @@ public final class MqttToPubSubBridge {
       }
       return numId;
     } catch (Exception e) {
-      // The logic for etcd to return a device ID is CLEAN for a NULL/No Value - this is not an error case!!!
-      logger.debug("No numId value or error reading from etcd for device {}/{}", registryId, deviceId);
+      // etcd returning a device ID is CLEAN for a NULL/No Value - not an error case
+      logger.debug("No numId value or error reading from etcd for device {}/{}",
+          registryId, deviceId);
       return null;
     }
   }

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -1,12 +1,16 @@
 package com.google.bos.udmi.service.bridge;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.rpc.FixedTransportChannelProvider;
 import com.google.bos.udmi.service.support.EtcdDataProvider;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.common.base.Splitter;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
@@ -77,23 +81,31 @@ import udmi.schema.IotAccess.IotProvider;
 /**
  * A bridge that subscribes to an MQTT topic and publishes messages to a Google Cloud Pub/Sub topic.
  */
-public final class MqttToPubSubBridge {
+public class MqttToPubSubBridge {
 
   private static final Pattern TOPIC_PATTERN = Pattern.compile("/r/([^/]+)/d/([^/]+)/?(.*)");
   private static final Logger logger = LoggerFactory.getLogger(MqttToPubSubBridge.class);
 
   private static final int MAX_QUEUE_SIZE = 99;
   private static final int NUM_THREADS = Runtime.getRuntime().availableProcessors() * 2;
-  // Change rejection policy to AbortPolicy to throw RejectedExecutionException when queue is full.
-  private static final ThreadPoolExecutor executor = new ThreadPoolExecutor(
-      NUM_THREADS, NUM_THREADS,
-      0L, TimeUnit.MILLISECONDS,
-      new ArrayBlockingQueue<>(MAX_QUEUE_SIZE),
-      new ThreadPoolExecutor.AbortPolicy());
+  
+  private final ThreadPoolExecutor executor;
+  private volatile boolean tripped = false;
 
-  private static volatile boolean tripped = false;
+  public MqttToPubSubBridge() {
+    this.executor = new ThreadPoolExecutor(
+        NUM_THREADS, NUM_THREADS,
+        0L, TimeUnit.MILLISECONDS,
+        new ArrayBlockingQueue<>(MAX_QUEUE_SIZE),
+        new ThreadFactoryBuilder().setNameFormat("mqtt-bridge-%d").setDaemon(true).build(),
+        new ThreadPoolExecutor.CallerRunsPolicy());
+  }
 
-  private static void startCircuitBreaker(IMqttClient mqttClient, ThreadPoolExecutor executor) {
+  public boolean isTripped() {
+    return tripped;
+  }
+
+  private void startCircuitBreaker(IMqttClient mqttClient) {
     Thread monitor = new Thread(() -> {
       long fullStartTime = 0;
       while (!tripped) {
@@ -111,7 +123,6 @@ public final class MqttToPubSubBridge {
               } catch (Exception e) {
                 logger.error("Error disconnecting during circuit breaker trip", e);
               }
-              System.exit(1);
             }
           } else {
             fullStartTime = 0; // reset
@@ -149,6 +160,8 @@ public final class MqttToPubSubBridge {
         commandLine.getOptionValue("mqtt_subscription_topic", "/r/+/d/#");
     String gcpProjectId = commandLine.getOptionValue("gcp_project_id");
     String pubsubTopicId = commandLine.getOptionValue("pubsub_topic_id");
+    String mqttClientId = commandLine.getOptionValue("mqtt_client_id");
+    String mqttSessionExpiryInterval = commandLine.getOptionValue("mqtt_session_expiry_interval");
     boolean mqttTls = commandLine.hasOption("mqtt_tls");
     String mqttCaPath = commandLine.getOptionValue("mqtt_ca_path");
     String mqttUsername = commandLine.getOptionValue("mqtt_username");
@@ -160,9 +173,14 @@ public final class MqttToPubSubBridge {
     String sourceAttribute = commandLine.getOptionValue("source_attribute", "bridge");
     String sharedSubscription = commandLine.getOptionValue("shared_subscription");
 
-    if (gcpProjectId == null || pubsubTopicId == null) {
-      logger.error("gcp_project_id and pubsub_topic_id are required.");
+    if (gcpProjectId == null || pubsubTopicId == null || mqttClientId == null) {
+      logger.error("gcp_project_id, pubsub_topic_id, and mqtt_client_id are required.");
       System.exit(1);
+    }
+    
+    Long sessionExpiryInterval = 0xFFFFFFFFL;
+    if (mqttSessionExpiryInterval != null) {
+      sessionExpiryInterval = Long.parseLong(mqttSessionExpiryInterval);
     }
 
     Publisher publisher = null;
@@ -174,17 +192,12 @@ public final class MqttToPubSubBridge {
       publisher = createPublisher(gcpProjectId, pubsubTopicId);
 
       // Initialize MQTT Client
-      String mqttClientId = System.getenv("MQTT_CLIENT_ID");
-      if (mqttClientId == null || mqttClientId.isEmpty()) {
-        mqttClientId = java.util.UUID.randomUUID().toString();
-      }
-
       mqttClient =
           new MqttClient(
               mqttBrokerUrl, mqttClientId, new MemoryPersistence());
       MqttConnectionOptions connOpts = new MqttConnectionOptions();
       connOpts.setCleanStart(false);
-      connOpts.setSessionExpiryInterval(0xFFFFFFFFL); // No session expiry
+      connOpts.setSessionExpiryInterval(sessionExpiryInterval);
       connOpts.setAutomaticReconnect(true);
       connOpts.setReceiveMaximum(100);
 
@@ -204,15 +217,17 @@ public final class MqttToPubSubBridge {
       mqttClient.connect(connOpts);
       logger.debug("Connected to MQTT broker.");
 
+      MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+
       // Start the circuit breaker monitor
-      startCircuitBreaker(mqttClient, executor);
+      bridge.startCircuitBreaker(mqttClient);
 
       // Set up MQTT Message Callback
-      setupBridge(mqttClient, publisher, mqttSubscriptionTopic,
+      bridge.setupBridge(mqttClient, publisher, mqttSubscriptionTopic,
           etcdProvider, sourceAttribute, sharedSubscription);
 
       // Keep the application running
-      while (true) {
+      while (!bridge.isTripped()) {
         try {
           Thread.sleep(10000);
         } catch (InterruptedException e) {
@@ -262,6 +277,8 @@ public final class MqttToPubSubBridge {
     options.addOption(null, "mqtt_subscription_topic", true, "MQTT subscription topic.");
     options.addOption(null, "gcp_project_id", true, "Google Cloud Project ID.");
     options.addOption(null, "pubsub_topic_id", true, "Google Cloud Pub/Sub topic ID.");
+    options.addOption(null, "mqtt_client_id", true, "MQTT client ID.");
+    options.addOption(null, "mqtt_session_expiry_interval", true, "MQTT session expiry interval (seconds).");
     options.addOption(null, "mqtt_tls", false, "Enable TLS for MQTT connection.");
     options.addOption(null, "mqtt_ca_path", true, "Path to CA certificate for TLS.");
     options.addOption(null, "mqtt_username", true, "MQTT username for authentication.");
@@ -294,7 +311,7 @@ public final class MqttToPubSubBridge {
    * @param mqttSubscriptionTopic The MQTT topic to subscribe to.
    * @throws MqttException If an MQTT error occurs.
    */
-  public static void setupBridge(IMqttClient mqttClient, Publisher publisher,
+  public void setupBridge(IMqttClient mqttClient, Publisher publisher,
       String mqttSubscriptionTopic, EtcdDataProvider etcdProvider) throws MqttException {
     setupBridge(mqttClient, publisher, mqttSubscriptionTopic, etcdProvider, "bridge", null);
   }
@@ -308,7 +325,7 @@ public final class MqttToPubSubBridge {
    * @param sourceAttribute       The value of the source attribute.
    * @throws MqttException If an MQTT error occurs.
    */
-  public static void setupBridge(IMqttClient mqttClient, Publisher publisher,
+  public void setupBridge(IMqttClient mqttClient, Publisher publisher,
       String mqttSubscriptionTopic, EtcdDataProvider etcdProvider, String sourceAttribute)
       throws MqttException {
     setupBridge(mqttClient, publisher, mqttSubscriptionTopic, etcdProvider, sourceAttribute, null);
@@ -317,7 +334,7 @@ public final class MqttToPubSubBridge {
   /**
    * Sets up the bridge between MQTT and Pub/Sub with a custom source attribute value.
    */
-  public static void setupBridge(IMqttClient mqttClient, Publisher publisher,
+  public void setupBridge(IMqttClient mqttClient, Publisher publisher,
       String mqttSubscriptionTopic, EtcdDataProvider etcdProvider, String sourceAttribute,
       String sharedSubscription)
       throws MqttException {
@@ -363,7 +380,7 @@ public final class MqttToPubSubBridge {
           @Override
           public void messageArrived(String topic, MqttMessage message) {
             try {
-              final String recieveTime = java.time.Instant.now().toString();
+              final String receiveTime = java.time.Instant.now().toString();
               executor.submit(() -> {
                 try {
                   byte[] payload = message.getPayload();
@@ -396,8 +413,8 @@ public final class MqttToPubSubBridge {
                   attributes.put("mqttTopic", parsedTopic);
                   attributes.put("deviceId", deviceId);
                   attributes.put("deviceRegistryId", registryId);
-                  attributes.put("recieveTime", recieveTime);
-                  attributes.put("distributeClientId", mqttClient.getClientId());
+                  attributes.put("receiveTime", receiveTime);
+                  attributes.put("distributorClientId", mqttClient.getClientId());
                   if (sourceAttribute != null) {
                     attributes.put("source", sourceAttribute);
                   }
@@ -415,35 +432,29 @@ public final class MqttToPubSubBridge {
                   }
 
                   ByteString data = ByteString.copyFrom(payload);
-                  PubsubMessage.Builder pubsubMessageBuilder =
-                      PubsubMessage.newBuilder().setData(data);
+                  PubsubMessage.Builder pubsubMessageBuilder = PubsubMessage.newBuilder().setData(data);
 
                   PubsubMessage pubsubMessage =
                       pubsubMessageBuilder.putAllAttributes(attributes).build();
 
-                  // Publish to Pub/Sub with local retries
-                  long backoff = 100;
-                  while (!tripped) {
-                    try {
-                      ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
-                      String msgId = messageIdFuture.get(); // blocks until complete
+                  // Publish to Pub/Sub and acknowledge asynchronously
+                  ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
+                  ApiFutures.addCallback(messageIdFuture, new ApiFutureCallback<String>() {
+                    @Override
+                    public void onSuccess(String msgId) {
                       logger.debug("Published to Pub/Sub with message ID: {}", msgId);
-                      mqttClient.messageArrivedComplete(message.getId(), message.getQos());
-                      break; // success
-                    } catch (Exception e) {
-                      // Note: Poison pills (e.g., consistently failing serialization) could
-                      // permanently block this thread since we retry indefinitely,
-                      // but schema validation happens earlier in the pipeline.
-                      logger.warn("Error publishing to Pub/Sub, retrying in {} ms", backoff, e);
                       try {
-                        Thread.sleep(backoff);
-                      } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        break;
+                        mqttClient.messageArrivedComplete(message.getId(), message.getQos());
+                      } catch (MqttException e) {
+                        logger.error("Failed to ACK MQTT message, it will be redelivered", e);
                       }
-                      backoff = Math.min(backoff * 2, 10000);
                     }
-                  }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                      logger.warn("Error publishing to Pub/Sub, dropping ACK so broker can redeliver", t);
+                    }
+                  }, MoreExecutors.directExecutor());
 
                 } catch (RuntimeException e) {
                   logger.warn("Error processing MQTT message", e);
@@ -620,6 +631,4 @@ public final class MqttToPubSubBridge {
       return null;
     }
   }
-
-  private MqttToPubSubBridge() {}
 }

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -30,7 +30,12 @@ import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.KeyManagerFactory;
@@ -58,14 +63,16 @@ import org.bouncycastle.openssl.PEMKeyPair;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder;
-import org.eclipse.paho.client.mqttv3.IMqttClient;
-import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
-import org.eclipse.paho.client.mqttv3.MqttCallbackExtended;
-import org.eclipse.paho.client.mqttv3.MqttClient;
-import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
-import org.eclipse.paho.client.mqttv3.MqttException;
-import org.eclipse.paho.client.mqttv3.MqttMessage;
-import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.eclipse.paho.mqttv5.client.IMqttClient;
+import org.eclipse.paho.mqttv5.client.IMqttToken;
+import org.eclipse.paho.mqttv5.client.MqttCallback;
+import org.eclipse.paho.mqttv5.client.MqttClient;
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.MqttDisconnectResponse;
+import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import udmi.schema.IotAccess;
@@ -78,6 +85,50 @@ public final class MqttToPubSubBridge {
 
   private static final Pattern TOPIC_PATTERN = Pattern.compile("/r/([^/]+)/d/([^/]+)/?(.*)");
   private static final Logger logger = LoggerFactory.getLogger(MqttToPubSubBridge.class);
+
+  private static final int MAX_QUEUE_SIZE = 99;
+  private static final int NUM_THREADS = Runtime.getRuntime().availableProcessors() * 2;
+  // Change rejection policy to AbortPolicy to throw RejectedExecutionException when queue is full.
+  private static final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+      NUM_THREADS, NUM_THREADS,
+      0L, TimeUnit.MILLISECONDS,
+      new ArrayBlockingQueue<>(MAX_QUEUE_SIZE),
+      new ThreadPoolExecutor.AbortPolicy());
+
+  private static volatile boolean tripped = false;
+
+  private static void startCircuitBreaker(IMqttClient mqttClient, ThreadPoolExecutor executor) {
+    Thread monitor = new Thread(() -> {
+      long fullStartTime = 0;
+      while (!tripped) {
+        try {
+          Thread.sleep(1000);
+          // Check if we've received the maximum number of inflight messages (100)
+          if (executor.getActiveCount() + executor.getQueue().size() >= 100) {
+            if (fullStartTime == 0) {
+              fullStartTime = System.currentTimeMillis();
+            } else if (System.currentTimeMillis() - fullStartTime >= 60000) {
+              tripped = true;
+              logger.error("Queue saturated for 60 seconds! Tripping circuit breaker.");
+              try {
+                mqttClient.disconnect();
+              } catch (Exception e) {
+                logger.error("Error disconnecting during circuit breaker trip", e);
+              }
+              System.exit(1);
+            }
+          } else {
+            fullStartTime = 0; // reset
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+    });
+    monitor.setDaemon(true);
+    monitor.start();
+  }
 
   /**
    * Main entry point for the bridge.
@@ -111,6 +162,7 @@ public final class MqttToPubSubBridge {
     String etcdTarget = commandLine.getOptionValue("etcd_target");
     String etcdOptions = commandLine.getOptionValue("etcd_options");
     String sourceAttribute = commandLine.getOptionValue("source_attribute", "bridge");
+    String sharedSubscription = commandLine.getOptionValue("shared_subscription");
 
     if (gcpProjectId == null || pubsubTopicId == null) {
       logger.error("gcp_project_id and pubsub_topic_id are required.");
@@ -126,19 +178,25 @@ public final class MqttToPubSubBridge {
       publisher = createPublisher(gcpProjectId, pubsubTopicId);
 
       // Initialize MQTT Client
+      String mqttClientId = System.getenv("MQTT_CLIENT_ID");
+      if (mqttClientId == null || mqttClientId.isEmpty()) {
+        mqttClientId = java.util.UUID.randomUUID().toString();
+      }
 
-      // Initialize MQTT Client
       mqttClient =
-          new MqttClient(mqttBrokerUrl, MqttClient.generateClientId(), new MemoryPersistence());
-      MqttConnectOptions connOpts = new MqttConnectOptions();
-      connOpts.setCleanSession(true);
+          new MqttClient(
+              mqttBrokerUrl, mqttClientId, new MemoryPersistence());
+      MqttConnectionOptions connOpts = new MqttConnectionOptions();
+      connOpts.setCleanStart(false);
+      connOpts.setSessionExpiryInterval(0xFFFFFFFFL); // No session expiry
       connOpts.setAutomaticReconnect(true);
+      connOpts.setReceiveMaximum(100);
 
       if (mqttUsername != null && !mqttUsername.isEmpty()) {
         connOpts.setUserName(mqttUsername);
       }
       if (mqttPassword != null && !mqttPassword.isEmpty()) {
-        connOpts.setPassword(mqttPassword.toCharArray());
+        connOpts.setPassword(mqttPassword.getBytes(StandardCharsets.UTF_8));
       }
 
       if (mqttTls) {
@@ -146,12 +204,15 @@ public final class MqttToPubSubBridge {
             getSocketFactory(mqttCaPath, mqttClientCertPath, mqttClientKeyPath, ""));
       }
 
-      logger.info("Connecting to MQTT broker: {}", mqttBrokerUrl);
+      logger.debug("Connecting to MQTT broker: {}", mqttBrokerUrl);
       mqttClient.connect(connOpts);
-      logger.info("Connected to MQTT broker.");
+      logger.debug("Connected to MQTT broker.");
+
+      // Start the circuit breaker monitor
+      startCircuitBreaker(mqttClient, executor);
 
       // Set up MQTT Message Callback
-      setupBridge(mqttClient, publisher, mqttSubscriptionTopic, etcdProvider, sourceAttribute);
+      setupBridge(mqttClient, publisher, mqttSubscriptionTopic, etcdProvider, sourceAttribute, sharedSubscription);
 
       // Keep the application running
       while (true) {
@@ -174,7 +235,7 @@ public final class MqttToPubSubBridge {
       if (etcdProvider != null) {
         try {
           etcdProvider.shutdown();
-          logger.info("EtcdDataProvider shut down.");
+          logger.debug("EtcdDataProvider shut down.");
         } catch (Exception e) {
           logger.warn("Error shutting down EtcdDataProvider", e);
         }
@@ -182,7 +243,7 @@ public final class MqttToPubSubBridge {
       if (mqttClient != null && mqttClient.isConnected()) {
         try {
           mqttClient.disconnect();
-          logger.info("MQTT client disconnected.");
+          logger.debug("MQTT client disconnected.");
         } catch (MqttException e) {
           logger.warn("Error disconnecting MQTT client", e);
         }
@@ -190,7 +251,7 @@ public final class MqttToPubSubBridge {
       if (publisher != null) {
         try {
           publisher.shutdown();
-          logger.info("Pub/Sub Publisher shut down.");
+          logger.debug("Pub/Sub Publisher shut down.");
         } catch (Exception e) {
           logger.warn("Error shutting down Pub/Sub publisher", e);
         }
@@ -213,6 +274,7 @@ public final class MqttToPubSubBridge {
     options.addOption(null, "etcd_target", true, "etcd endpoint URL.");
     options.addOption(null, "etcd_options", true, "etcd provider options (comma-separated).");
     options.addOption(null, "source_attribute", true, "Value for the source attribute.");
+    options.addOption(null, "shared_subscription", true, "Shared subscription name.");
     options.addOption("h", "help", false, "Print usage info.");
 
     CommandLineParser parser = new DefaultParser();
@@ -237,7 +299,7 @@ public final class MqttToPubSubBridge {
    */
   public static void setupBridge(IMqttClient mqttClient, Publisher publisher,
       String mqttSubscriptionTopic, EtcdDataProvider etcdProvider) throws MqttException {
-    setupBridge(mqttClient, publisher, mqttSubscriptionTopic, etcdProvider, "bridge");
+    setupBridge(mqttClient, publisher, mqttSubscriptionTopic, etcdProvider, "bridge", null);
   }
 
   /**
@@ -252,101 +314,159 @@ public final class MqttToPubSubBridge {
   public static void setupBridge(IMqttClient mqttClient, Publisher publisher,
       String mqttSubscriptionTopic, EtcdDataProvider etcdProvider, String sourceAttribute)
       throws MqttException {
+    setupBridge(mqttClient, publisher, mqttSubscriptionTopic, etcdProvider, sourceAttribute, null);
+  }
+
+  public static void setupBridge(IMqttClient mqttClient, Publisher publisher,
+      String mqttSubscriptionTopic, EtcdDataProvider etcdProvider, String sourceAttribute,
+      String sharedSubscription)
+      throws MqttException {
+    
+    final String actualSubscriptionTopic;
+    if (sharedSubscription != null && !sharedSubscription.isEmpty() && !mqttSubscriptionTopic.startsWith("$share/")) {
+      actualSubscriptionTopic = String.format("$share/%s/%s", sharedSubscription, mqttSubscriptionTopic);
+    } else {
+      actualSubscriptionTopic = mqttSubscriptionTopic;
+    }
+
+    mqttClient.setManualAcks(true);
     mqttClient.setCallback(
-        new MqttCallbackExtended() {
+        new MqttCallback() {
           @Override
           public void connectComplete(boolean reconnect, String serverUri) {
             if (reconnect) {
-              logger.info("MQTT automatically reconnected to broker: {}", serverUri);
+              logger.debug("MQTT automatically reconnected to broker: {}", serverUri);
               try {
-                mqttClient.subscribe(mqttSubscriptionTopic);
-                logger.info("Successfully re-subscribed to topic: {}", mqttSubscriptionTopic);
+                mqttClient.subscribe(actualSubscriptionTopic, 1);
+                logger.debug("Successfully re-subscribed to topic: {}", actualSubscriptionTopic);
               } catch (MqttException e) {
                 logger.error("Failed to re-subscribe to topic {} after auto-reconnect",
                     mqttSubscriptionTopic, e);
               }
             } else {
-              logger.info("Initial MQTT connection established to broker: {}", serverUri);
+              logger.debug("Initial MQTT connection established to broker: {}", serverUri);
             }
           }
 
           @Override
-          public void connectionLost(Throwable cause) {
-            logger.warn("MQTT connection lost", cause);
+          public void disconnected(MqttDisconnectResponse disconnectResponse) {
+            logger.warn("MQTT connection lost", disconnectResponse.getException());
+          }
+
+          @Override
+          public void mqttErrorOccurred(MqttException exception) {
+            logger.warn("MQTT error occurred", exception);
           }
 
           @Override
           public void messageArrived(String topic, MqttMessage message) {
             try {
-              byte[] payload = message.getPayload();
-              logger.info(
-                  "MQTT Message Received - Topic: {}, Payload Length: {}", topic, payload.length);
+              final String recieveTime = java.time.Instant.now().toString();
+              executor.submit(() -> {
+                try {
+                  byte[] payload = message.getPayload();
+                  logger.debug(
+                      "MQTT Message Received - Topic: {}, Payload Length: {}", topic, payload.length);
 
-              Matcher matcher = TOPIC_PATTERN.matcher(topic);
-              String registryId = "unknown";
-              String deviceId = "unknown";
-              String topicSuffix = "";
-              if (matcher.matches()) {
-                registryId = matcher.group(1);
-                deviceId = matcher.group(2);
-                topicSuffix = matcher.group(3);
-              } else {
-                logger.warn("Could not parse registry/device from topic: {}", topic);
-              }
-
-              // Prepare Pub/Sub message
-              Map<String, String> attributes = new HashMap<>();
-              attributes.put("mqttTopic", topic);
-              attributes.put("deviceId", deviceId);
-              attributes.put("deviceRegistryId", registryId);
-              if (sourceAttribute != null) {
-                attributes.put("source", sourceAttribute);
-              }
-
-              String numId = getDeviceNumId(etcdProvider, registryId, deviceId);
-              if (numId != null) {
-                attributes.put("deviceNumId", numId);
-              }
-
-              if (topicSuffix != null && topicSuffix.startsWith("events/")) {
-                List<String> parts = Splitter.on('/').splitToList(topicSuffix);
-                if (parts.size() >= 2) {
-                  attributes.put("subFolder", parts.get(1));
-                }
-              }
-
-              ByteString data = ByteString.copyFrom(payload);
-              PubsubMessage.Builder pubsubMessageBuilder =
-                  PubsubMessage.newBuilder().setData(data);
-
-              PubsubMessage pubsubMessage =
-                  pubsubMessageBuilder.putAllAttributes(attributes).build();
-
-              // Publish to Pub/Sub
-              ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
-              messageIdFuture.addListener(
-                  () -> {
-                    try {
-                      logger.info(
-                          "Published to Pub/Sub with message ID: {}", messageIdFuture.get());
-                    } catch (InterruptedException | ExecutionException e) {
-                      logger.warn("Error publishing to Pub/Sub", e);
+                  String parsedTopic = topic;
+                  // Automatically strip the shared subscription prefix if present
+                  if (parsedTopic.startsWith("$share/")) {
+                    parsedTopic = parsedTopic.replaceFirst("^\\$share/[^/]+/", "");
+                    if (!parsedTopic.startsWith("/")) {
+                      parsedTopic = "/" + parsedTopic;
                     }
-                  },
-                  directExecutor());
+                  }
 
-            } catch (RuntimeException e) {
-              logger.warn("Error processing MQTT message", e);
+                  Matcher matcher = TOPIC_PATTERN.matcher(parsedTopic);
+                  String registryId = "unknown";
+                  String deviceId = "unknown";
+                  String topicSuffix = "";
+                  if (matcher.matches()) {
+                    registryId = matcher.group(1);
+                    deviceId = matcher.group(2);
+                    topicSuffix = matcher.group(3);
+                  } else {
+                    logger.warn("Could not parse registry/device from topic: {}", parsedTopic);
+                  }
+
+                  // Prepare Pub/Sub message
+                  Map<String, String> attributes = new HashMap<>();
+                  attributes.put("mqttTopic", parsedTopic);
+                  attributes.put("deviceId", deviceId);
+                  attributes.put("deviceRegistryId", registryId);
+                  attributes.put("recieveTime", recieveTime);
+                  attributes.put("distributeClientId", mqttClient.getClientId());
+                  if (sourceAttribute != null) {
+                    attributes.put("source", sourceAttribute);
+                  }
+
+                  String numId = getDeviceNumId(etcdProvider, registryId, deviceId);
+                  if (numId != null) {
+                    attributes.put("deviceNumId", numId);
+                  }
+
+                  if (topicSuffix != null && topicSuffix.startsWith("events/")) {
+                    List<String> parts = Splitter.on('/').splitToList(topicSuffix);
+                    if (parts.size() >= 2) {
+                      attributes.put("subFolder", parts.get(1));
+                    }
+                  }
+
+                  ByteString data = ByteString.copyFrom(payload);
+                  PubsubMessage.Builder pubsubMessageBuilder =
+                      PubsubMessage.newBuilder().setData(data);
+
+                  PubsubMessage pubsubMessage =
+                      pubsubMessageBuilder.putAllAttributes(attributes).build();
+
+                  // Publish to Pub/Sub with local retries
+                  long backoff = 100;
+                  while (!tripped) {
+                    try {
+                      ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
+                      String msgId = messageIdFuture.get(); // blocks until complete
+                      logger.debug("Published to Pub/Sub with message ID: {}", msgId);
+                      mqttClient.messageArrivedComplete(message.getId(), message.getQos());
+                      break; // success
+                    } catch (Exception e) {
+                      // Note: Poison pills (e.g., consistently failing serialization) could
+                      // permanently block this thread since we retry indefinitely, but
+                      // schema validation happens earlier in the pipeline so it is not a concern here.
+                      logger.warn("Error publishing to Pub/Sub, retrying in {} ms", backoff, e);
+                      try {
+                        Thread.sleep(backoff);
+                      } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        break;
+                      }
+                      backoff = Math.min(backoff * 2, 10000);
+                    }
+                  }
+
+                } catch (RuntimeException e) {
+                  logger.warn("Error processing MQTT message", e);
+                }
+              });
+            } catch (RejectedExecutionException e) {
+              logger.error("Execution rejected, queue is full! Dropping MQTT connection to mitigate stall.", e);
+              try {
+                mqttClient.disconnectForcibly();
+              } catch (MqttException me) {
+                logger.error("Error while forcing disconnect", me);
+              }
             }
           }
 
           @Override
-          public void deliveryComplete(IMqttDeliveryToken token) {}
+          public void deliveryComplete(IMqttToken token) {}
+
+          @Override
+          public void authPacketArrived(int reasonCode, MqttProperties properties) {}
         });
 
-    logger.info("Subscribing to MQTT topic: {}", mqttSubscriptionTopic);
-    mqttClient.subscribe(mqttSubscriptionTopic);
-    logger.info("Subscribed. Waiting for messages...");
+    logger.debug("Subscribing to MQTT topic: {}", actualSubscriptionTopic);
+    mqttClient.subscribe(actualSubscriptionTopic, 1);
+    logger.debug("Subscribed. Waiting for messages...");
   }
 
   private static SSLSocketFactory getSocketFactory(
@@ -448,7 +568,7 @@ public final class MqttToPubSubBridge {
     iotAccess.project_id = target;
     iotAccess.options = options;
     EtcdDataProvider provider = new EtcdDataProvider(iotAccess);
-    logger.info("EtcdDataProvider initialized for target: {}", target);
+    logger.debug("EtcdDataProvider initialized for target: {}", target);
     return provider;
   }
 
@@ -464,11 +584,11 @@ public final class MqttToPubSubBridge {
       publisherBuilder.setChannelProvider(
           FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel)));
       publisherBuilder.setCredentialsProvider(NoCredentialsProvider.create());
-      logger.info("Routing Pub/Sub Publisher to emulator host: {}", useHost);
+      logger.debug("Routing Pub/Sub Publisher to emulator host: {}", useHost);
     }
     try {
       Publisher publisher = publisherBuilder.build();
-      logger.info("Pub/Sub Publisher initialized for topic: {}", topicName);
+      logger.debug("Pub/Sub Publisher initialized for topic: {}", topicName);
       return publisher;
     } catch (IOException e) {
       throw new RuntimeException("Failed to build Pub/Sub Publisher", e);
@@ -486,13 +606,14 @@ public final class MqttToPubSubBridge {
           .device(deviceId)
           .get("num_id");
       if (numId != null) {
-        logger.info("Found numId {} in etcd for device {}/{}", numId, registryId, deviceId);
+        logger.debug("Found numId {} in etcd for device {}/{}", numId, registryId, deviceId);
       } else {
-        logger.warn("numId not found in etcd for device {}/{}", registryId, deviceId);
+        logger.debug("numId not found in etcd for device {}/{}", registryId, deviceId);
       }
       return numId;
     } catch (Exception e) {
-      logger.warn("Error reading numId from etcd for device {}/{}", registryId, deviceId, e);
+      // The logic for etcd to return a device ID is CLEAN for a NULL/No Value - this is not an error case!!!
+      logger.debug("No numId value or error reading from etcd for device {}/{}", registryId, deviceId);
       return null;
     }
   }

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -62,7 +62,7 @@ class MqttToPubSubBridgeTest {
     assertEquals("my-registry", attributes.get("deviceRegistryId"));
     assertEquals("bridge", attributes.get("source"));
     org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("receiveTime"));
-    assertEquals("test-client", attributes.get("distributeClientId"));
+    assertEquals("test-client", attributes.get("distributorClientId"));
   }
 
   @Test
@@ -97,7 +97,7 @@ class MqttToPubSubBridgeTest {
     assertEquals("my-registry", attributes.get("deviceRegistryId"));
     assertEquals("subfolder_name", attributes.get("subFolder"));
     org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("receiveTime"));
-    assertEquals("test-client", attributes.get("distributeClientId"));
+    assertEquals("test-client", attributes.get("distributorClientId"));
   }
 
   @Test
@@ -131,7 +131,7 @@ class MqttToPubSubBridgeTest {
     assertEquals("unknown", attributes.get("deviceId"));
     assertEquals("unknown", attributes.get("deviceRegistryId"));
     org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("receiveTime"));
-    assertEquals("test-client", attributes.get("distributeClientId"));
+    assertEquals("test-client", attributes.get("distributorClientId"));
   }
 
   @Test
@@ -155,7 +155,8 @@ class MqttToPubSubBridgeTest {
     when(mockDataRef.device("my-device")).thenReturn(mockDataRef);
     when(mockDataRef.get("num_id")).thenReturn("123456");
 
-    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
+    new MqttToPubSubBridge()
+        .setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
 
     ArgumentCaptor<MqttCallback> callbackCaptor =
         ArgumentCaptor.forClass(MqttCallback.class);
@@ -194,7 +195,8 @@ class MqttToPubSubBridgeTest {
     when(mockDataRef.device("my-device")).thenReturn(mockDataRef);
     when(mockDataRef.get("num_id")).thenReturn(null);
 
-    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
+    new MqttToPubSubBridge()
+        .setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
 
     ArgumentCaptor<MqttCallback> callbackCaptor =
         ArgumentCaptor.forClass(MqttCallback.class);
@@ -233,7 +235,8 @@ class MqttToPubSubBridgeTest {
     when(mockDataRef.device("my-device")).thenReturn(mockDataRef);
     when(mockDataRef.get("num_id")).thenThrow(new RuntimeException("etcd error"));
 
-    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
+    new MqttToPubSubBridge()
+        .setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
 
     ArgumentCaptor<MqttCallback> callbackCaptor =
         ArgumentCaptor.forClass(MqttCallback.class);
@@ -294,7 +297,8 @@ class MqttToPubSubBridgeTest {
         .thenReturn(ApiFutures.immediateFuture("msg-123"));
 
     // Call 5-parameter setupBridge with custom source attribute
-    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, null, "custom-source");
+    new MqttToPubSubBridge()
+        .setupBridge(mockMqttClient, mockPublisher, testTopic, null, "custom-source");
 
     verify(mockMqttClient).subscribe(testTopic, 1);
 
@@ -328,11 +332,13 @@ class MqttToPubSubBridgeTest {
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFuture("msg-123"));
 
-    // Note: The double-slash before 'r' is expected because the MQTT topic explicitly starts with a slash
-    // (e.g. "/r/..."). Thus, "$share/my-group/" concatenated with "/r/..." correctly yields the double slash.
+    // Note: The double-slash before 'r' is expected because the MQTT topic explicitly
+    // starts with a slash (e.g. "/r/..."). Thus, "$share/my-group/" concatenated with
+    // "/r/..." correctly yields the double slash.
     // Call setupBridge with shared subscription
-    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, originalTopic, null,
-        "bridge", sharedSubscriptionName);
+    new MqttToPubSubBridge()
+        .setupBridge(mockMqttClient, mockPublisher, originalTopic, null,
+            "bridge", sharedSubscriptionName);
 
     // Verify it subscribed to the shared subscription filter
     verify(mockMqttClient).subscribe(expectedFilter, 1);

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -329,7 +329,8 @@ class MqttToPubSubBridgeTest {
         .thenReturn(ApiFutures.immediateFuture("msg-123"));
 
     // Call setupBridge with shared subscription
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, originalTopic, null, "bridge", sharedSubscriptionName);
+    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, originalTopic, null,
+        "bridge", sharedSubscriptionName);
 
     // Verify it subscribed to the shared subscription filter
     verify(mockMqttClient).subscribe(expectedFilter, 1);

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -12,9 +12,9 @@ import com.google.bos.udmi.service.support.EtcdDataProvider;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.pubsub.v1.PubsubMessage;
 import java.util.Map;
-import org.eclipse.paho.client.mqttv3.IMqttClient;
-import org.eclipse.paho.client.mqttv3.MqttCallbackExtended;
-import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.mqttv5.client.IMqttClient;
+import org.eclipse.paho.mqttv5.client.MqttCallback;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -23,6 +23,7 @@ class MqttToPubSubBridgeTest {
   @Test
   void testSetupBridge() throws Exception {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
     String testTopic = "/r/my-registry/d/my-device/events";
     String payloadStr = "Hello World";
@@ -36,13 +37,13 @@ class MqttToPubSubBridgeTest {
     MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
     // Verify subscription
-    verify(mockMqttClient).subscribe(testTopic);
+    verify(mockMqttClient).subscribe(testTopic, 1);
 
     // Capture callback
-    ArgumentCaptor<MqttCallbackExtended> callbackCaptor =
-        ArgumentCaptor.forClass(MqttCallbackExtended.class);
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
-    MqttCallbackExtended callback = callbackCaptor.getValue();
+    MqttCallback callback = callbackCaptor.getValue();
 
     // Simulate message arrival
     callback.messageArrived(testTopic, mqttMessage);
@@ -50,7 +51,7 @@ class MqttToPubSubBridgeTest {
     // Verify Pub/Sub publish
     ArgumentCaptor<PubsubMessage> pubsubMessageCaptor =
         ArgumentCaptor.forClass(PubsubMessage.class);
-    verify(mockPublisher).publish(pubsubMessageCaptor.capture());
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000)).publish(pubsubMessageCaptor.capture());
 
     PubsubMessage pubsubMessage = pubsubMessageCaptor.getValue();
     assertEquals(payloadStr, pubsubMessage.getData().toStringUtf8());
@@ -60,11 +61,14 @@ class MqttToPubSubBridgeTest {
     assertEquals("my-device", attributes.get("deviceId"));
     assertEquals("my-registry", attributes.get("deviceRegistryId"));
     assertEquals("bridge", attributes.get("source"));
+    org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("recieveTime"));
+    assertEquals("test-client", attributes.get("distributeClientId"));
   }
 
   @Test
   void testSetupBridgeWithSubFolder() throws Exception {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
     String testTopic = "/r/my-registry/d/my-device/events/subfolder_name";
     String payloadStr = "Hello World";
@@ -75,16 +79,16 @@ class MqttToPubSubBridgeTest {
 
     MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
-    ArgumentCaptor<MqttCallbackExtended> callbackCaptor =
-        ArgumentCaptor.forClass(MqttCallbackExtended.class);
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
-    MqttCallbackExtended callback = callbackCaptor.getValue();
+    MqttCallback callback = callbackCaptor.getValue();
 
     callback.messageArrived(testTopic, mqttMessage);
 
     ArgumentCaptor<PubsubMessage> pubsubMessageCaptor =
         ArgumentCaptor.forClass(PubsubMessage.class);
-    verify(mockPublisher).publish(pubsubMessageCaptor.capture());
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000)).publish(pubsubMessageCaptor.capture());
 
     PubsubMessage pubsubMessage = pubsubMessageCaptor.getValue();
     Map<String, String> attributes = pubsubMessage.getAttributesMap();
@@ -92,11 +96,14 @@ class MqttToPubSubBridgeTest {
     assertEquals("my-device", attributes.get("deviceId"));
     assertEquals("my-registry", attributes.get("deviceRegistryId"));
     assertEquals("subfolder_name", attributes.get("subFolder"));
+    org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("recieveTime"));
+    assertEquals("test-client", attributes.get("distributeClientId"));
   }
 
   @Test
   void testSetupBridgeUnrecognizedTopic() throws Exception {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
     String testTopic = "invalid/topic/structure";
     String payloadStr = "Hello World";
@@ -107,27 +114,30 @@ class MqttToPubSubBridgeTest {
 
     MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
-    ArgumentCaptor<MqttCallbackExtended> callbackCaptor =
-        ArgumentCaptor.forClass(MqttCallbackExtended.class);
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
-    MqttCallbackExtended callback = callbackCaptor.getValue();
+    MqttCallback callback = callbackCaptor.getValue();
 
     callback.messageArrived(testTopic, mqttMessage);
 
     ArgumentCaptor<PubsubMessage> pubsubMessageCaptor =
         ArgumentCaptor.forClass(PubsubMessage.class);
-    verify(mockPublisher).publish(pubsubMessageCaptor.capture());
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000)).publish(pubsubMessageCaptor.capture());
 
     PubsubMessage pubsubMessage = pubsubMessageCaptor.getValue();
     Map<String, String> attributes = pubsubMessage.getAttributesMap();
     assertEquals(testTopic, attributes.get("mqttTopic"));
     assertEquals("unknown", attributes.get("deviceId"));
     assertEquals("unknown", attributes.get("deviceRegistryId"));
+    org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("recieveTime"));
+    assertEquals("test-client", attributes.get("distributeClientId"));
   }
 
   @Test
   void testSetupBridgeWithEtcd() throws Exception {
     final IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
     final Publisher mockPublisher = mock(Publisher.class);
     final EtcdDataProvider mockEtcdProvider = mock(EtcdDataProvider.class);
     final DataRef mockDataRef = mock(DataRef.class);
@@ -147,16 +157,16 @@ class MqttToPubSubBridgeTest {
 
     MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
 
-    ArgumentCaptor<MqttCallbackExtended> callbackCaptor =
-        ArgumentCaptor.forClass(MqttCallbackExtended.class);
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
-    MqttCallbackExtended callback = callbackCaptor.getValue();
+    MqttCallback callback = callbackCaptor.getValue();
 
     callback.messageArrived(testTopic, mqttMessage);
 
     ArgumentCaptor<PubsubMessage> pubsubMessageCaptor =
         ArgumentCaptor.forClass(PubsubMessage.class);
-    verify(mockPublisher).publish(pubsubMessageCaptor.capture());
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000)).publish(pubsubMessageCaptor.capture());
 
     PubsubMessage pubsubMessage = pubsubMessageCaptor.getValue();
     Map<String, String> attributes = pubsubMessage.getAttributesMap();
@@ -166,6 +176,7 @@ class MqttToPubSubBridgeTest {
   @Test
   void testSetupBridgeWithEtcdNullResult() throws Exception {
     final IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
     final Publisher mockPublisher = mock(Publisher.class);
     final EtcdDataProvider mockEtcdProvider = mock(EtcdDataProvider.class);
     final DataRef mockDataRef = mock(DataRef.class);
@@ -185,16 +196,16 @@ class MqttToPubSubBridgeTest {
 
     MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
 
-    ArgumentCaptor<MqttCallbackExtended> callbackCaptor =
-        ArgumentCaptor.forClass(MqttCallbackExtended.class);
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
-    MqttCallbackExtended callback = callbackCaptor.getValue();
+    MqttCallback callback = callbackCaptor.getValue();
 
     callback.messageArrived(testTopic, mqttMessage);
 
     ArgumentCaptor<PubsubMessage> pubsubMessageCaptor =
         ArgumentCaptor.forClass(PubsubMessage.class);
-    verify(mockPublisher).publish(pubsubMessageCaptor.capture());
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000)).publish(pubsubMessageCaptor.capture());
 
     PubsubMessage pubsubMessage = pubsubMessageCaptor.getValue();
     Map<String, String> attributes = pubsubMessage.getAttributesMap();
@@ -204,6 +215,7 @@ class MqttToPubSubBridgeTest {
   @Test
   void testSetupBridgeWithEtcdFailure() throws Exception {
     final IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
     final Publisher mockPublisher = mock(Publisher.class);
     final EtcdDataProvider mockEtcdProvider = mock(EtcdDataProvider.class);
     final DataRef mockDataRef = mock(DataRef.class);
@@ -223,17 +235,17 @@ class MqttToPubSubBridgeTest {
 
     MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
 
-    ArgumentCaptor<MqttCallbackExtended> callbackCaptor =
-        ArgumentCaptor.forClass(MqttCallbackExtended.class);
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
-    MqttCallbackExtended callback = callbackCaptor.getValue();
+    MqttCallback callback = callbackCaptor.getValue();
 
     // This should not throw exception and message should still be published
     callback.messageArrived(testTopic, mqttMessage);
 
     ArgumentCaptor<PubsubMessage> pubsubMessageCaptor =
         ArgumentCaptor.forClass(PubsubMessage.class);
-    verify(mockPublisher).publish(pubsubMessageCaptor.capture());
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000)).publish(pubsubMessageCaptor.capture());
 
     PubsubMessage pubsubMessage = pubsubMessageCaptor.getValue();
     Map<String, String> attributes = pubsubMessage.getAttributesMap();
@@ -243,18 +255,20 @@ class MqttToPubSubBridgeTest {
   @Test
   void testSetupBridgeAutoReconnect() throws Exception {
     final IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
     final Publisher mockPublisher = mock(Publisher.class);
     final String testTopic = "/r/my-registry/d/my-device/events";
 
     MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
     // Verify initial subscription
-    verify(mockMqttClient).subscribe(testTopic);
+    verify(mockMqttClient).subscribe(testTopic, 1);
 
-    ArgumentCaptor<MqttCallbackExtended> callbackCaptor =
-        ArgumentCaptor.forClass(MqttCallbackExtended.class);
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
-    MqttCallbackExtended callback = callbackCaptor.getValue();
+    verify(mockMqttClient).setManualAcks(true);
+    MqttCallback callback = callbackCaptor.getValue();
 
     // Simulate initial connection completed (reconnect = false)
     callback.connectComplete(false, "tcp://localhost:1883");
@@ -264,12 +278,13 @@ class MqttToPubSubBridgeTest {
     // Simulate automatic reconnection completed (reconnect = true)
     callback.connectComplete(true, "tcp://localhost:1883");
     // Verify re-subscribed
-    verify(mockMqttClient, org.mockito.Mockito.times(2)).subscribe(testTopic);
+    verify(mockMqttClient, org.mockito.Mockito.times(2)).subscribe(testTopic, 1);
   }
 
   @Test
   void testSetupBridgeWithCustomSource() throws Exception {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
     String testTopic = "/r/my-registry/d/my-device/events";
     String payloadStr = "Hello World";
@@ -281,22 +296,64 @@ class MqttToPubSubBridgeTest {
     // Call 5-parameter setupBridge with custom source attribute
     MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null, "custom-source");
 
-    verify(mockMqttClient).subscribe(testTopic);
+    verify(mockMqttClient).subscribe(testTopic, 1);
 
-    ArgumentCaptor<MqttCallbackExtended> callbackCaptor =
-        ArgumentCaptor.forClass(MqttCallbackExtended.class);
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
-    MqttCallbackExtended callback = callbackCaptor.getValue();
+    MqttCallback callback = callbackCaptor.getValue();
 
     callback.messageArrived(testTopic, mqttMessage);
 
     ArgumentCaptor<PubsubMessage> pubsubMessageCaptor =
         ArgumentCaptor.forClass(PubsubMessage.class);
-    verify(mockPublisher).publish(pubsubMessageCaptor.capture());
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000)).publish(pubsubMessageCaptor.capture());
 
     PubsubMessage pubsubMessage = pubsubMessageCaptor.getValue();
     Map<String, String> attributes = pubsubMessage.getAttributesMap();
     assertEquals("custom-source", attributes.get("source"));
   }
 
+  @Test
+  void testSetupBridgeWithSharedSubscription() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String originalTopic = "/r/my-registry/d/my-device/events";
+    String sharedSubscriptionName = "my-group";
+    String expectedFilter = "$share/my-group//r/my-registry/d/my-device/events";
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
+
+    when(mockPublisher.publish(any(PubsubMessage.class)))
+        .thenReturn(ApiFutures.immediateFuture("msg-123"));
+
+    // Call setupBridge with shared subscription
+    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, originalTopic, null, "bridge", sharedSubscriptionName);
+
+    // Verify it subscribed to the shared subscription filter
+    verify(mockMqttClient).subscribe(expectedFilter, 1);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    // The broker will typically send the original topic without the $share prefix
+    // but we'll test the automatic topic parsing by passing the $share prefixed topic
+    callback.messageArrived(expectedFilter, mqttMessage);
+
+    ArgumentCaptor<PubsubMessage> pubsubMessageCaptor =
+        ArgumentCaptor.forClass(PubsubMessage.class);
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000)).publish(pubsubMessageCaptor.capture());
+
+    PubsubMessage pubsubMessage = pubsubMessageCaptor.getValue();
+    Map<String, String> attributes = pubsubMessage.getAttributesMap();
+
+    // Should correctly strip $share/my-group/ and parse the registry and device
+    assertEquals(originalTopic, attributes.get("mqttTopic"));
+    assertEquals("my-device", attributes.get("deviceId"));
+    assertEquals("my-registry", attributes.get("deviceRegistryId"));
+  }
 }
+

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -34,7 +34,7 @@ class MqttToPubSubBridgeTest {
         .thenReturn(ApiFutures.immediateFuture("msg-123"));
 
     // Call setupBridge
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
     // Verify subscription
     verify(mockMqttClient).subscribe(testTopic, 1);
@@ -61,7 +61,7 @@ class MqttToPubSubBridgeTest {
     assertEquals("my-device", attributes.get("deviceId"));
     assertEquals("my-registry", attributes.get("deviceRegistryId"));
     assertEquals("bridge", attributes.get("source"));
-    org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("recieveTime"));
+    org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("receiveTime"));
     assertEquals("test-client", attributes.get("distributeClientId"));
   }
 
@@ -77,7 +77,7 @@ class MqttToPubSubBridgeTest {
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFuture("msg-123"));
 
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
     ArgumentCaptor<MqttCallback> callbackCaptor =
         ArgumentCaptor.forClass(MqttCallback.class);
@@ -96,7 +96,7 @@ class MqttToPubSubBridgeTest {
     assertEquals("my-device", attributes.get("deviceId"));
     assertEquals("my-registry", attributes.get("deviceRegistryId"));
     assertEquals("subfolder_name", attributes.get("subFolder"));
-    org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("recieveTime"));
+    org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("receiveTime"));
     assertEquals("test-client", attributes.get("distributeClientId"));
   }
 
@@ -112,7 +112,7 @@ class MqttToPubSubBridgeTest {
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFuture("msg-123"));
 
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
     ArgumentCaptor<MqttCallback> callbackCaptor =
         ArgumentCaptor.forClass(MqttCallback.class);
@@ -130,7 +130,7 @@ class MqttToPubSubBridgeTest {
     assertEquals(testTopic, attributes.get("mqttTopic"));
     assertEquals("unknown", attributes.get("deviceId"));
     assertEquals("unknown", attributes.get("deviceRegistryId"));
-    org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("recieveTime"));
+    org.junit.jupiter.api.Assertions.assertNotNull(attributes.get("receiveTime"));
     assertEquals("test-client", attributes.get("distributeClientId"));
   }
 
@@ -155,7 +155,7 @@ class MqttToPubSubBridgeTest {
     when(mockDataRef.device("my-device")).thenReturn(mockDataRef);
     when(mockDataRef.get("num_id")).thenReturn("123456");
 
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
 
     ArgumentCaptor<MqttCallback> callbackCaptor =
         ArgumentCaptor.forClass(MqttCallback.class);
@@ -194,7 +194,7 @@ class MqttToPubSubBridgeTest {
     when(mockDataRef.device("my-device")).thenReturn(mockDataRef);
     when(mockDataRef.get("num_id")).thenReturn(null);
 
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
 
     ArgumentCaptor<MqttCallback> callbackCaptor =
         ArgumentCaptor.forClass(MqttCallback.class);
@@ -233,7 +233,7 @@ class MqttToPubSubBridgeTest {
     when(mockDataRef.device("my-device")).thenReturn(mockDataRef);
     when(mockDataRef.get("num_id")).thenThrow(new RuntimeException("etcd error"));
 
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, mockEtcdProvider);
 
     ArgumentCaptor<MqttCallback> callbackCaptor =
         ArgumentCaptor.forClass(MqttCallback.class);
@@ -259,7 +259,7 @@ class MqttToPubSubBridgeTest {
     final Publisher mockPublisher = mock(Publisher.class);
     final String testTopic = "/r/my-registry/d/my-device/events";
 
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
     // Verify initial subscription
     verify(mockMqttClient).subscribe(testTopic, 1);
@@ -294,7 +294,7 @@ class MqttToPubSubBridgeTest {
         .thenReturn(ApiFutures.immediateFuture("msg-123"));
 
     // Call 5-parameter setupBridge with custom source attribute
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null, "custom-source");
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, null, "custom-source");
 
     verify(mockMqttClient).subscribe(testTopic, 1);
 
@@ -328,8 +328,10 @@ class MqttToPubSubBridgeTest {
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFuture("msg-123"));
 
+    // Note: The double-slash before 'r' is expected because the MQTT topic explicitly starts with a slash
+    // (e.g. "/r/..."). Thus, "$share/my-group/" concatenated with "/r/..." correctly yields the double slash.
     // Call setupBridge with shared subscription
-    MqttToPubSubBridge.setupBridge(mockMqttClient, mockPublisher, originalTopic, null,
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, originalTopic, null,
         "bridge", sharedSubscriptionName);
 
     // Verify it subscribed to the shared subscription filter


### PR DESCRIPTION
- use MQTTv5 with support for shared subscriptions
- use a queue for message processing
- add client id command line option, and publish this (along with receieve time) to PubSub
- make missing device num id a non-error
- panic and exit if the queue remains full 