### PR TITLE
Update UDMIS and PubSub Relay to support etcd SSL with client certificates

### DIFF
--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -138,7 +138,7 @@ public final class MqttToPubSubBridge {
     EtcdDataProvider etcdProvider = null;
 
     try {
-      etcdProvider = createEtcdProvider(etcdTarget, etcdOptions);
+      etcdProvider = createEtcdProvider(etcdTarget, etcdOptions, commandLine);
       publisher = createPublisher(gcpProjectId, pubsubTopicId);
 
       // Initialize MQTT Client
@@ -460,7 +460,8 @@ public final class MqttToPubSubBridge {
         new SubjectPublicKeyInfo(algId, rsaPublicKey), new PrivateKeyInfo(algId, rsaPrivateKey));
   }
 
-  private static EtcdDataProvider createEtcdProvider(String target, String options) {
+  private static EtcdDataProvider createEtcdProvider(String target, String options,
+      CommandLine commandLine) {
     if (target == null) {
       return null;
     }
@@ -468,6 +469,20 @@ public final class MqttToPubSubBridge {
     iotAccess.provider = IotProvider.ETCD;
     iotAccess.project_id = target;
     iotAccess.options = options;
+
+    if (commandLine.hasOption("etcd_ssl")
+        || commandLine.hasOption("etcd_ca_path")
+        || commandLine.hasOption("etcd_client_cert_path")
+        || commandLine.hasOption("etcd_client_key_path")) {
+      iotAccess.endpoint = new udmi.schema.EndpointConfiguration();
+      if (commandLine.hasOption("etcd_ssl")) {
+        iotAccess.endpoint.transport = udmi.schema.EndpointConfiguration.Transport.SSL;
+      }
+      iotAccess.endpoint.ca_file = commandLine.getOptionValue("etcd_ca_path");
+      iotAccess.endpoint.cert_file = commandLine.getOptionValue("etcd_client_cert_path");
+      iotAccess.endpoint.key_file = commandLine.getOptionValue("etcd_client_key_path");
+    }
+
     EtcdDataProvider provider = new EtcdDataProvider(iotAccess);
     logger.info("EtcdDataProvider initialized for target: {}", target);
     return provider;

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -100,8 +100,8 @@ public final class MqttToPubSubBridge {
     String mqttBrokerUrl = commandLine.getOptionValue("mqtt_broker_url", "tcp://localhost:1883");
     String mqttSubscriptionTopic =
         commandLine.getOptionValue("mqtt_subscription_topic", "/r/+/d/#");
-    String gcpProjectId = commandLine.getOptionValue("gcp_project_id");
-    String pubsubTopicId = commandLine.getOptionValue("pubsub_topic_id");
+    final String gcpProjectId = commandLine.getOptionValue("gcp_project_id");
+    final String pubsubTopicId = commandLine.getOptionValue("pubsub_topic_id");
     boolean mqttTls = commandLine.hasOption("mqtt_tls");
     String mqttCaPath = commandLine.getOptionValue("mqtt_ca_path");
     String mqttUsername = commandLine.getOptionValue("mqtt_username");
@@ -111,6 +111,22 @@ public final class MqttToPubSubBridge {
     String etcdTarget = commandLine.getOptionValue("etcd_target");
     String etcdOptions = commandLine.getOptionValue("etcd_options");
     String sourceAttribute = commandLine.getOptionValue("source_attribute", "bridge");
+
+    if (commandLine.hasOption("etcd_ssl")) {
+      etcdOptions = (etcdOptions == null ? "" : etcdOptions + ",") + "ssl=true";
+    }
+    if (commandLine.hasOption("etcd_ca_path")) {
+      etcdOptions = (etcdOptions == null ? "" : etcdOptions + ",") + "ca_path="
+          + commandLine.getOptionValue("etcd_ca_path");
+    }
+    if (commandLine.hasOption("etcd_client_cert_path")) {
+      etcdOptions = (etcdOptions == null ? "" : etcdOptions + ",") + "client_cert_path="
+          + commandLine.getOptionValue("etcd_client_cert_path");
+    }
+    if (commandLine.hasOption("etcd_client_key_path")) {
+      etcdOptions = (etcdOptions == null ? "" : etcdOptions + ",") + "client_key_path="
+          + commandLine.getOptionValue("etcd_client_key_path");
+    }
 
     if (gcpProjectId == null || pubsubTopicId == null) {
       logger.error("gcp_project_id and pubsub_topic_id are required.");
@@ -212,6 +228,11 @@ public final class MqttToPubSubBridge {
     options.addOption(null, "mqtt_client_key_path", true, "Path to client private key for TLS.");
     options.addOption(null, "etcd_target", true, "etcd endpoint URL.");
     options.addOption(null, "etcd_options", true, "etcd provider options (comma-separated).");
+    options.addOption(null, "etcd_ssl", false, "Enable SSL for etcd.");
+    options.addOption(null, "etcd_ca_path", true, "Path to CA certificate for etcd SSL.");
+    options.addOption(null, "etcd_client_cert_path", true,
+        "Path to client certificate for etcd SSL.");
+    options.addOption(null, "etcd_client_key_path", true, "Path to client key for etcd SSL.");
     options.addOption(null, "source_attribute", true, "Value for the source attribute.");
     options.addOption("h", "help", false, "Print usage info.");
 

--- a/udmis/src/main/java/com/google/bos/udmi/service/pod/UdmiServicePod.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/pod/UdmiServicePod.java
@@ -35,10 +35,16 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.jetbrains.annotations.NotNull;
 import udmi.schema.BridgePodConfiguration;
 import udmi.schema.EndpointConfiguration;
 import udmi.schema.IotAccess;
+import udmi.schema.IotAccess.IotProvider;
 import udmi.schema.Level;
 import udmi.schema.PodConfiguration;
 import udmi.schema.SetupUdmiConfig;
@@ -64,6 +70,7 @@ public class UdmiServicePod extends ContainerBase {
       TargetProcessor.class, ReflectProcessor.class, StateProcessor.class, ControlProcessor.class,
       ProvisioningEngine.class, BitboxAdapter.class, DistributorPipe.class, UufiProcessor.class);
   private static final Map<String, Class<? extends ProcessorBase>> PROCESSORS = new HashMap<>();
+  private static CommandLine podCommandLine;
 
   static {
     PROCESSOR_CLASSES.forEach(clazz -> PROCESSORS.put(ContainerBase.getName(clazz), clazz));
@@ -170,11 +177,30 @@ public class UdmiServicePod extends ContainerBase {
     }
   }
 
-  private static PodConfiguration makePodConfiguration(String[] args) {
-    if (args.length != 1) {
-      throw new RuntimeException("Exactly one argument expected: pod_config.json");
+  private static CommandLine parseArgs(String[] args) {
+    Options options = new Options();
+    options.addOption(null, "etcd_ssl", false, "Enable SSL for etcd.");
+    options.addOption(null, "etcd_ca_path", true, "Path to CA certificate for etcd SSL.");
+    options.addOption(null, "etcd_client_cert_path", true,
+        "Path to client certificate for etcd SSL.");
+    options.addOption(null, "etcd_client_key_path", true, "Path to client key for etcd SSL.");
+
+    CommandLineParser parser = new DefaultParser();
+    try {
+      CommandLine commandLine = parser.parse(options, args);
+      if (commandLine.getArgList().size() != 1) {
+        throw new RuntimeException("Exactly one positional argument expected: pod_config.json");
+      }
+      return commandLine;
+    } catch (ParseException e) {
+      throw new RuntimeException("While parsing command line arguments", e);
     }
-    PodConfiguration config = loadRecursive(new File(args[0]));
+  }
+
+  private static PodConfiguration makePodConfiguration(String[] args) {
+    podCommandLine = parseArgs(args);
+    String configPath = podCommandLine.getArgList().get(0);
+    PodConfiguration config = loadRecursive(new File(configPath));
     System.err.println(stringify(config));
     ifNotNullThrow(config.include, "unresolved config include directive");
     return config;
@@ -219,8 +245,30 @@ public class UdmiServicePod extends ContainerBase {
     config.name = name;
   }
 
+  private void applyEtcdOptions(IotAccess config) {
+    if (config.provider != IotProvider.ETCD) {
+      return;
+    }
+    if (podCommandLine.hasOption("etcd_ssl")) {
+      config.options = (config.options == null ? "" : config.options + ",") + "ssl=true";
+    }
+    if (podCommandLine.hasOption("etcd_ca_path")) {
+      config.options = (config.options == null ? "" : config.options + ",") + "ca_path="
+          + podCommandLine.getOptionValue("etcd_ca_path");
+    }
+    if (podCommandLine.hasOption("etcd_client_cert_path")) {
+      config.options = (config.options == null ? "" : config.options + ",") + "client_cert_path="
+          + podCommandLine.getOptionValue("etcd_client_cert_path");
+    }
+    if (podCommandLine.hasOption("etcd_client_key_path")) {
+      config.options = (config.options == null ? "" : config.options + ",") + "client_key_path="
+          + podCommandLine.getOptionValue("etcd_client_key_path");
+    }
+  }
+
   private void createAccess(String name, IotAccess config) {
     config.name = name;
+    applyEtcdOptions(config);
     putComponent(name, () -> IotAccessProvider.from(config));
   }
 
@@ -251,6 +299,7 @@ public class UdmiServicePod extends ContainerBase {
 
   private void createIotData(String name, IotAccess config) {
     config.name = name;
+    applyEtcdOptions(config);
     putComponent(name, () -> IotDataProvider.from(config));
   }
 

--- a/udmis/src/main/java/com/google/bos/udmi/service/pod/UdmiServicePod.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/pod/UdmiServicePod.java
@@ -35,16 +35,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
 import org.jetbrains.annotations.NotNull;
 import udmi.schema.BridgePodConfiguration;
 import udmi.schema.EndpointConfiguration;
 import udmi.schema.IotAccess;
-import udmi.schema.IotAccess.IotProvider;
 import udmi.schema.Level;
 import udmi.schema.PodConfiguration;
 import udmi.schema.SetupUdmiConfig;
@@ -70,7 +64,6 @@ public class UdmiServicePod extends ContainerBase {
       TargetProcessor.class, ReflectProcessor.class, StateProcessor.class, ControlProcessor.class,
       ProvisioningEngine.class, BitboxAdapter.class, DistributorPipe.class, UufiProcessor.class);
   private static final Map<String, Class<? extends ProcessorBase>> PROCESSORS = new HashMap<>();
-  private static CommandLine podCommandLine;
 
   static {
     PROCESSOR_CLASSES.forEach(clazz -> PROCESSORS.put(ContainerBase.getName(clazz), clazz));
@@ -177,30 +170,11 @@ public class UdmiServicePod extends ContainerBase {
     }
   }
 
-  private static CommandLine parseArgs(String[] args) {
-    Options options = new Options();
-    options.addOption(null, "etcd_ssl", false, "Enable SSL for etcd.");
-    options.addOption(null, "etcd_ca_path", true, "Path to CA certificate for etcd SSL.");
-    options.addOption(null, "etcd_client_cert_path", true,
-        "Path to client certificate for etcd SSL.");
-    options.addOption(null, "etcd_client_key_path", true, "Path to client key for etcd SSL.");
-
-    CommandLineParser parser = new DefaultParser();
-    try {
-      CommandLine commandLine = parser.parse(options, args);
-      if (commandLine.getArgList().size() != 1) {
-        throw new RuntimeException("Exactly one positional argument expected: pod_config.json");
-      }
-      return commandLine;
-    } catch (ParseException e) {
-      throw new RuntimeException("While parsing command line arguments", e);
-    }
-  }
-
   private static PodConfiguration makePodConfiguration(String[] args) {
-    podCommandLine = parseArgs(args);
-    String configPath = podCommandLine.getArgList().get(0);
-    PodConfiguration config = loadRecursive(new File(configPath));
+    if (args.length != 1) {
+      throw new RuntimeException("Exactly one argument expected: pod_config.json");
+    }
+    PodConfiguration config = loadRecursive(new File(args[0]));
     System.err.println(stringify(config));
     ifNotNullThrow(config.include, "unresolved config include directive");
     return config;
@@ -245,30 +219,8 @@ public class UdmiServicePod extends ContainerBase {
     config.name = name;
   }
 
-  private void applyEtcdOptions(IotAccess config) {
-    if (config.provider != IotProvider.ETCD) {
-      return;
-    }
-    if (podCommandLine.hasOption("etcd_ssl")) {
-      config.options = (config.options == null ? "" : config.options + ",") + "ssl=true";
-    }
-    if (podCommandLine.hasOption("etcd_ca_path")) {
-      config.options = (config.options == null ? "" : config.options + ",") + "ca_path="
-          + podCommandLine.getOptionValue("etcd_ca_path");
-    }
-    if (podCommandLine.hasOption("etcd_client_cert_path")) {
-      config.options = (config.options == null ? "" : config.options + ",") + "client_cert_path="
-          + podCommandLine.getOptionValue("etcd_client_cert_path");
-    }
-    if (podCommandLine.hasOption("etcd_client_key_path")) {
-      config.options = (config.options == null ? "" : config.options + ",") + "client_key_path="
-          + podCommandLine.getOptionValue("etcd_client_key_path");
-    }
-  }
-
   private void createAccess(String name, IotAccess config) {
     config.name = name;
-    applyEtcdOptions(config);
     putComponent(name, () -> IotAccessProvider.from(config));
   }
 
@@ -299,7 +251,6 @@ public class UdmiServicePod extends ContainerBase {
 
   private void createIotData(String name, IotAccess config) {
     config.name = name;
-    applyEtcdOptions(config);
     putComponent(name, () -> IotDataProvider.from(config));
   }
 

--- a/udmis/src/main/java/com/google/bos/udmi/service/support/EtcdDataProvider.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/support/EtcdDataProvider.java
@@ -5,12 +5,14 @@ import static com.google.bos.udmi.service.core.DistributorPipe.clientId;
 import static com.google.udmi.util.GeneralUtils.CSV_JOINER;
 import static com.google.udmi.util.GeneralUtils.friendlyStackTrace;
 import static com.google.udmi.util.GeneralUtils.ifNotNullGet;
+import static com.google.udmi.util.GeneralUtils.ifNotNullThen;
 import static com.google.udmi.util.GeneralUtils.isNullOrNotEmpty;
 
 import com.google.bos.udmi.service.pod.ContainerBase;
 import com.google.udmi.util.GeneralUtils;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
+import io.etcd.jetcd.ClientBuilder;
 import io.etcd.jetcd.KV;
 import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.Lock;
@@ -20,6 +22,8 @@ import io.etcd.jetcd.op.Op;
 import io.etcd.jetcd.options.DeleteOption;
 import io.etcd.jetcd.options.GetOption;
 import io.etcd.jetcd.options.PutOption;
+import io.netty.handler.ssl.SslContextBuilder;
+import java.io.File;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
@@ -39,7 +43,12 @@ import udmi.schema.IotAccess;
 public class EtcdDataProvider extends ContainerBase implements IotDataProvider {
 
   public static final GetOption PREFIXED_OPTION = GetOption.newBuilder().isPrefix(true).build();
-  private static final String EXPECTED_PREFIX = "http://";
+  private static final String SSL_KEY = "ssl";
+  private static final String CA_PATH_KEY = "ca_path";
+  private static final String CLIENT_CERT_PATH_KEY = "client_cert_path";
+  private static final String CLIENT_KEY_PATH_KEY = "client_key_path";
+  private static final String HTTP_PREFIX = "http://";
+  private static final String HTTPS_PREFIX = "https://";
   private static final String RESULTING_PREFIX = "ip:///";
   private static final long QUERY_TIMEOUT_SEC = 10;
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(QUERY_TIMEOUT_SEC);
@@ -117,9 +126,31 @@ public class EtcdDataProvider extends ContainerBase implements IotDataProvider {
     }
   }
 
+  private ClientBuilder createClientBuilder(String target) {
+    ClientBuilder builder = Client.builder().target(target);
+    if (TRUE_OPTION.equals(options.get(SSL_KEY))) {
+      try {
+        SslContextBuilder sslContextBuilder = SslContextBuilder.forClient();
+        ifNotNullThen(options.get(CA_PATH_KEY),
+            path -> sslContextBuilder.trustManager(new File(path)));
+        String clientCertPath = options.get(CLIENT_CERT_PATH_KEY);
+        String clientKeyPath = options.get(CLIENT_KEY_PATH_KEY);
+        if (clientCertPath != null && clientKeyPath != null) {
+          sslContextBuilder.keyManager(new File(clientCertPath), new File(clientKeyPath));
+        }
+        builder.sslContext(sslContextBuilder.build());
+      } catch (Exception e) {
+        throw new RuntimeException("While building SSL context for etcd", e);
+      }
+    }
+    return builder;
+  }
+
   private Client initializeClient() {
     String target = variableSubstitution(config.project_id, "undefined project_id");
-    try (Client tmpClient = Client.builder().target(target).build()) {
+    boolean ssl = TRUE_OPTION.equals(options.get(SSL_KEY));
+    String expectedPrefix = ssl ? HTTPS_PREFIX : HTTP_PREFIX;
+    try (Client tmpClient = createClientBuilder(target).build()) {
       info("Connecting to etcd target %s to glean client list", target);
       List<Member> members =
           tmpClient.getClusterClient().listMember().get(QUERY_TIMEOUT_SEC, TimeUnit.SECONDS)
@@ -127,13 +158,13 @@ public class EtcdDataProvider extends ContainerBase implements IotDataProvider {
       Set<String> uris = members.stream().flatMap(member -> member.getClientURIs().stream())
           .map(URI::toString).collect(Collectors.toSet());
       checkState(!uris.isEmpty(), "no member uris found");
-      checkState(uris.stream().allMatch(uri -> uri.startsWith(EXPECTED_PREFIX)),
-          "inconsistent prefix");
-      String collected = uris.stream().map(uri -> uri.substring(EXPECTED_PREFIX.length()))
+      checkState(uris.stream().allMatch(uri -> uri.startsWith(expectedPrefix)),
+          "inconsistent prefix " + expectedPrefix);
+      String collected = uris.stream().map(uri -> uri.substring(expectedPrefix.length()))
           .collect(Collectors.joining(","));
       String targets = RESULTING_PREFIX + collected;
       info("Gleaned etcd client targets %s", targets);
-      Client client = Client.builder().target(targets).connectTimeout(CONNECT_TIMEOUT).build();
+      Client client = createClientBuilder(targets).connectTimeout(CONNECT_TIMEOUT).build();
       updateConnectedKey(client);
       reapConnectedKeys(client);
       return client;

--- a/udmis/src/main/java/com/google/bos/udmi/service/support/EtcdDataProvider.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/support/EtcdDataProvider.java
@@ -7,6 +7,7 @@ import static com.google.udmi.util.GeneralUtils.friendlyStackTrace;
 import static com.google.udmi.util.GeneralUtils.ifNotNullGet;
 import static com.google.udmi.util.GeneralUtils.ifNotNullThen;
 import static com.google.udmi.util.GeneralUtils.isNullOrNotEmpty;
+import static java.util.Optional.ofNullable;
 
 import com.google.bos.udmi.service.pod.ContainerBase;
 import com.google.udmi.util.GeneralUtils;
@@ -126,15 +127,35 @@ public class EtcdDataProvider extends ContainerBase implements IotDataProvider {
     }
   }
 
+  private String getCaPath() {
+    return ofNullable(options.get(CA_PATH_KEY))
+        .orElseGet(() -> ifNotNullGet(config.endpoint, x -> x.ca_file));
+  }
+
+  private String getClientCertPath() {
+    return ofNullable(options.get(CLIENT_CERT_PATH_KEY))
+        .orElseGet(() -> ifNotNullGet(config.endpoint, x -> x.cert_file));
+  }
+
+  private String getClientKeyPath() {
+    return ofNullable(options.get(CLIENT_KEY_PATH_KEY))
+        .orElseGet(() -> ifNotNullGet(config.endpoint, x -> x.key_file));
+  }
+
+  private boolean isSslEnabled() {
+    return TRUE_OPTION.equals(options.get(SSL_KEY))
+        || ifNotNullGet(config.endpoint,
+            x -> x.transport == udmi.schema.EndpointConfiguration.Transport.SSL, false);
+  }
+
   private ClientBuilder createClientBuilder(String target) {
     ClientBuilder builder = Client.builder().target(target);
-    if (TRUE_OPTION.equals(options.get(SSL_KEY))) {
+    if (isSslEnabled()) {
       try {
         SslContextBuilder sslContextBuilder = SslContextBuilder.forClient();
-        ifNotNullThen(options.get(CA_PATH_KEY),
-            path -> sslContextBuilder.trustManager(new File(path)));
-        String clientCertPath = options.get(CLIENT_CERT_PATH_KEY);
-        String clientKeyPath = options.get(CLIENT_KEY_PATH_KEY);
+        ifNotNullThen(getCaPath(), path -> sslContextBuilder.trustManager(new File(path)));
+        String clientCertPath = getClientCertPath();
+        String clientKeyPath = getClientKeyPath();
         if (clientCertPath != null && clientKeyPath != null) {
           sslContextBuilder.keyManager(new File(clientCertPath), new File(clientKeyPath));
         }
@@ -148,7 +169,7 @@ public class EtcdDataProvider extends ContainerBase implements IotDataProvider {
 
   private Client initializeClient() {
     String target = variableSubstitution(config.project_id, "undefined project_id");
-    boolean ssl = TRUE_OPTION.equals(options.get(SSL_KEY));
+    boolean ssl = isSslEnabled();
     String expectedPrefix = ssl ? HTTPS_PREFIX : HTTP_PREFIX;
     try (Client tmpClient = createClientBuilder(target).build()) {
       info("Connecting to etcd target %s to glean client list", target);


### PR DESCRIPTION
- Modified EtcdDataProvider to handle ssl, ca_path, client_cert_path, and client_key_path options.
- Updated EtcdDataProvider to use .target() instead of .endpoints() for better gRPC resolver support.
- Added CLI flags to MqttToPubSubBridge and UdmiServicePod for etcd SSL configuration.
- Ensured etcd connections do not use username/password authentication as per user feedback.
- Fixed regressions in MqttToPubSubBridge where variables were accidentally removed.