### PR TITLE
Convert start_influx to native execution and add native test workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -261,6 +261,8 @@ jobs:
           bin/pull_messages $TARGET_PROJECT > out/message_capture.log 2>&1 &
       - name: bin/test_etcd_prerun
         run: bin/test_etcd_prerun
+      - name: bin/test_influx_prerun
+        run: bin/test_influx_prerun
       - name: bin/test_mosquitto
         run: bin/test_mosquitto
       - name: bin/test_regclean
@@ -275,6 +277,8 @@ jobs:
         run: bin/test_udmis
       - name: bin/test_etcd_postrun
         run: bin/test_etcd_postrun
+      - name: bin/test_influx_postrun
+        run: bin/test_influx_postrun
       - name: mosquitto debug
         if: ${{ !cancelled() }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ credentials.json
 /udmis/profile/
 /udmis/.idea/libraries/
 /udmis/bin/etcd_bin/
+/udmis/bin/influx_bin/
 /selfie/build/
 /pubber/build/
 /pubber/out/
@@ -49,6 +50,7 @@ __pycache__/
 /tests/sites/*/out/
 /tests/sites/*/devices/*/out/
 /tests/sites/basic/extras/
+/tests/sites/*/reflector/
 /udmi_*.log
 
 .vscode

--- a/bin/start_influx
+++ b/bin/start_influx
@@ -2,23 +2,19 @@
 
 IMAGE=influxdb:v2.7.1
 
-function find_influx {
-    for path in \
-        "udmis/bin/influx_bin" \
-        "bin/influx_bin" \
-        "$(dirname $0)/influx_bin" \
-        "/root/bin/influx_bin" \
-        "/root/udmi/bin/influx_bin" \
-        "/tmp/influx"; do
-        if [[ -f "$path/influxd" ]]; then
-            echo "$path"
-            return 0
-        fi
-    done
-    return 1
-}
+UDMI_ROOT=$(dirname "$0")/..
+BINDIR="${UDMI_ROOT}/udmis/bin/influx_bin"
 
-BINDIR=$(find_influx) || BINDIR=/tmp/influx
+if [[ ! -f "$BINDIR/influxd" ]]; then
+    echo "influxd not found in $BINDIR. Attempting to download via influxctl..."
+    "${UDMI_ROOT}/udmis/bin/influxctl" version || true
+fi
+
+if [[ ! -f "$BINDIR/influxd" ]]; then
+    echo "Error: influxd executable not found at $BINDIR/influxd" >&2
+    exit 1
+fi
+
 INFLUX_LOG=out/influx.log
 
 echo pwd: $(pwd)
@@ -40,11 +36,6 @@ else
             kill $old_pid || true
         fi
     fi
-fi
-
-if [[ ! -f $BINDIR/influxd ]]; then
-    udmis/bin/influxctl version || ../bin/influxctl version || $(dirname $0)/influxctl version || true
-    BINDIR=$(find_influx) || BINDIR=/tmp/influx
 fi
 
 $BINDIR/influxd version

--- a/bin/start_influx
+++ b/bin/start_influx
@@ -1,15 +1,84 @@
 #!/bin/bash -e
 
-# https://lucassardois.medium.com/handling-iot-data-with-mqtt-telegraf-influxdb-and-grafana-5a431480217
+IMAGE=influxdb:v2.7.1
 
-docker run --name influxdb \
-       -v $PWD/influxdb-data:/var/lib/influxdb \
-       influxdb
+function find_influx {
+    for path in \
+        "udmis/bin/influx_bin" \
+        "bin/influx_bin" \
+        "$(dirname $0)/influx_bin" \
+        "/root/bin/influx_bin" \
+        "/root/udmi/bin/influx_bin" \
+        "/tmp/influx"; do
+        if [[ -f "$path/influxd" ]]; then
+            echo "$path"
+            return 0
+        fi
+    done
+    return 1
+}
 
-docker run --rm --name telegraf \
-       -v $PWD/telegraf.conf:/etc/telegraf/telegraf.conf:ro \
-       telegraf
-  
-docker run -d -p 3000:3000 --name grafana \
-       -v $PWD/grafana-data:/var/lib/grafana \
-       grafana/grafana
+BINDIR=$(find_influx) || BINDIR=/tmp/influx
+INFLUX_LOG=out/influx.log
+
+echo pwd: $(pwd)
+mkdir -p out var/influx
+
+INFLUX_PID_FILE=var/influx/influxd.pid
+if [[ -f $INFLUX_PID_FILE ]]; then
+    old_pid=$(cat $INFLUX_PID_FILE)
+    if ps -p $old_pid > /dev/null 2>&1; then
+        echo Killing existing local influxd pid $old_pid...
+        kill $old_pid || true
+        sleep 1
+    fi
+else
+    if [[ ${UDMI_NO_SUDO:-false} != true ]]; then
+        old_pid=$(ps ax | fgrep influxd | fgrep -v grep | awk '{print $1}') || true
+        if [[ -n $old_pid ]]; then
+            echo Killing existing influxd pid $old_pid...
+            kill $old_pid || true
+        fi
+    fi
+fi
+
+if [[ ! -f $BINDIR/influxd ]]; then
+    udmis/bin/influxctl version || ../bin/influxctl version || $(dirname $0)/influxctl version || true
+    BINDIR=$(find_influx) || BINDIR=/tmp/influx
+fi
+
+$BINDIR/influxd version
+
+rm -rf var/influx/*
+mkdir -p var/influx/engine
+
+influx_port=${INFLUX_PORT:-8086}
+
+nohup $BINDIR/influxd \
+             --http-bind-address=0.0.0.0:${influx_port} \
+             --engine-path var/influx/engine \
+             --bolt-path var/influx/influxd.bolt \
+             --sqlite-path var/influx/influxd.sqlite \
+             > $INFLUX_LOG 2>&1 &
+INFLUX_PID=$!
+echo $INFLUX_PID > $INFLUX_PID_FILE
+
+echo Waiting 10s for influxd to start on port ${influx_port}, log in $INFLUX_LOG
+sleep 10
+[[ -d /proc/$INFLUX_PID ]] || (cat $INFLUX_LOG && echo error starting influxd && false)
+
+echo Initializing InfluxDB default organization and bucket...
+INFLUX_USER=${INFLUX_USER:-bridgehead}
+INFLUX_PASSWORD=${INFLUX_PASSWORD:-password}
+INFLUXDB_ORG=${INFLUXDB_ORG:-bridgehead}
+INFLUXDB_BUCKET=${INFLUXDB_BUCKET:-home}
+INFLUXDB_TOKEN=${INFLUXDB_TOKEN:-test-influx-token-12345}
+
+udmis/bin/influxctl setup --force --name default \
+    --username "$INFLUX_USER" \
+    --password "$INFLUX_PASSWORD" \
+    --org "$INFLUXDB_ORG" \
+    --bucket "$INFLUXDB_BUCKET" \
+    --token "$INFLUXDB_TOKEN" || true
+
+echo Completed influxd startup.

--- a/bin/start_local
+++ b/bin/start_local
@@ -69,6 +69,9 @@ registry_id=$(jq -r .registry_id $site_config)${UDMI_REGISTRY_SUFFIX:-}
 echo Starting etcd... | tee -a $UDMIS_LOG
 $UDMI_ROOT/bin/start_etcd >> $UDMIS_LOG 2>&1
 
+echo Starting influx... | tee -a $UDMIS_LOG
+$UDMI_ROOT/bin/start_influx >> $UDMIS_LOG 2>&1
+
 source $UDMI_ROOT/etc/mosquitto_ctrl.sh
 mkdir -p $CERT_DIR
 

--- a/bin/test_influx_postrun
+++ b/bin/test_influx_postrun
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+set -x
+
+ROOT=$(dirname $0)/..
+
+source $ROOT/etc/shell_common.sh
+
+INFLUXDB_TOKEN=${INFLUXDB_TOKEN:-test-influx-token-12345}
+INFLUXDB_ORG=${INFLUXDB_ORG:-bridgehead}
+INFLUXDB_BUCKET=${INFLUXDB_BUCKET:-home}
+
+echo "Verifying organization and buckets in influxdb..."
+$ROOT/udmis/bin/influxctl bucket list --token "$INFLUXDB_TOKEN"
+
+echo "Writing test point to influxdb..."
+$ROOT/udmis/bin/influxctl write --token "$INFLUXDB_TOKEN" --org "$INFLUXDB_ORG" --bucket "$INFLUXDB_BUCKET" "test_metric,host=localhost value=42.0"
+
+echo "Querying test point from influxdb..."
+GOT_VAL=$($ROOT/udmis/bin/influxctl query --token "$INFLUXDB_TOKEN" --org "$INFLUXDB_ORG" 'from(bucket: "'"$INFLUXDB_BUCKET"'") |> range(start: -1m) |> filter(fn: (r) => r._measurement == "test_metric")' | fgrep test_metric || true)
+
+if [[ -n "$GOT_VAL" ]]; then
+    echo "SUCCESS: Metric correctly found in influxdb."
+else
+    echo "FAILURE: Metric NOT found in influxdb."
+    exit 1
+fi

--- a/bin/test_influx_prerun
+++ b/bin/test_influx_prerun
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+ROOT=$(dirname $0)/..
+
+source $ROOT/etc/shell_common.sh
+
+$ROOT/udmis/bin/influxctl ping

--- a/bridgehead/udmis/startup/udmis_startup.sh
+++ b/bridgehead/udmis/startup/udmis_startup.sh
@@ -31,7 +31,7 @@ sleep 12
 echo Starting udmis proper... | tee -a $UDMIS_LOG
 
 
-OLD_PID=$(ps ax | fgrep java | fgrep local_pod.json | awk '{print $1}') || true
+OLD_PID=$( (ps ax 2>/dev/null || ps) | fgrep java | fgrep local_pod.json | awk '{print $1}') || true
 if [[ -n $OLD_PID ]]; then
     echo Killing old udmis process $OLD_PID
     kill $OLD_PID
@@ -54,7 +54,7 @@ jq --arg u "$SERV_USER" --arg p "$SERV_PASS" --arg host_var "$MQTT_HOST" \
 '.flow_defaults.auth_provider.basic.username = $u | .flow_defaults.auth_provider.basic.password = $p | .flow_defaults.hostname=$host_var | .iot_access.implicit.endpoint.hostname=$host_var' \
 /root/var/local_pod.json > /root/var/local_pod.tmp && mv /root/var/local_pod.tmp /root/var/local_pod.json
 
-$UDMIS_DIR/bin/run /root/var/local_pod.json >> $LOGFILE 2>&1 &
+$(realpath $UDMIS_DIR/bin/run) /root/var/local_pod.json >> $LOGFILE 2>&1 &
 
 PID=$!
 
@@ -74,7 +74,7 @@ if [[ ! -f $POD_READY ]]; then
     echo "=== DIAGNOSTIC LOGS FOR UDMIS STARTUP FAILURE ==="
     echo "Host working directory: $PWD"
     echo "Process $PID status:"
-    ps -p $PID || echo "Process $PID not running"
+    kill -0 $PID 2>/dev/null && (ps -p $PID 2>/dev/null || ps | grep -E "^\s*${PID}\s") || echo "Process $PID not running"
     echo "Last 100 lines of $LOGFILE:"
     tail -n 100 $LOGFILE || true
     echo "=== END DIAGNOSTIC LOGS ==="

--- a/udmis/Dockerfile.udmis
+++ b/udmis/Dockerfile.udmis
@@ -13,6 +13,8 @@ ADD build/udmi_bin/ udmi/bin/
 
 ADD bin/ bin/
 
+RUN mkdir -p udmi/udmis && ln -s /root/bin udmi/udmis/bin
+
 RUN bin/etcdctl version
 RUN find / -name "*mosquitto_dynamic_security*" || true
 

--- a/udmis/bin/influxctl
+++ b/udmis/bin/influxctl
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+
+INFLUXD_VER=2.7.1
+INFLUX_CLI_VER=2.7.5
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+TARGET_DIR=${SCRIPT_DIR}/influx_bin
+
+if [[ ! -d ${TARGET_DIR} || ! -f ${TARGET_DIR}/influxd || ! -f ${TARGET_DIR}/influx ]]; then
+   rm -f /tmp/influxdb2-${INFLUXD_VER}-linux-amd64.tar.gz /tmp/influxdb2-client-${INFLUX_CLI_VER}-linux-amd64.tar.gz
+   mkdir -p ${TARGET_DIR}
+
+   curl -sL https://dl.influxdata.com/influxdb/releases/influxdb2-${INFLUXD_VER}-linux-amd64.tar.gz -o /tmp/influxdb2-${INFLUXD_VER}-linux-amd64.tar.gz
+   tar xzf /tmp/influxdb2-${INFLUXD_VER}-linux-amd64.tar.gz -C ${TARGET_DIR} --strip-components=1
+   rm -f /tmp/influxdb2-${INFLUXD_VER}-linux-amd64.tar.gz
+
+   curl -sL https://dl.influxdata.com/influxdb/releases/influxdb2-client-${INFLUX_CLI_VER}-linux-amd64.tar.gz -o /tmp/influxdb2-client-${INFLUX_CLI_VER}-linux-amd64.tar.gz
+   tar xzf /tmp/influxdb2-client-${INFLUX_CLI_VER}-linux-amd64.tar.gz -C ${TARGET_DIR}
+   rm -f /tmp/influxdb2-client-${INFLUX_CLI_VER}-linux-amd64.tar.gz
+
+   ${TARGET_DIR}/influxd version
+   ${TARGET_DIR}/influx version
+
+   echo
+   echo Download complete.
+   echo
+fi
+
+export INFLUX_HOST="http://127.0.0.1:${INFLUX_PORT:-8086}"
+export INFLUX_CONFIGS_PATH="${SCRIPT_DIR}/../../var/influx/configs"
+
+if [[ $# -gt 0 ]]; then
+    exec ${TARGET_DIR}/influx "$@"
+fi


### PR DESCRIPTION
Add native start_influx script, influxctl binary installer wrapper, and test_influx_prerun/postrun scripts for standalone local testing. Integrate influx native start into start_local and add test steps to CI.
