### PR TITLE
fix createDevice missing initial config in implicit iot access provider

### DIFF
--- a/udmis/src/main/java/com/google/bos/udmi/service/access/ImplicitIotAccessProvider.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/access/ImplicitIotAccessProvider.java
@@ -20,7 +20,6 @@ import static com.google.udmi.util.JsonUtil.stringifyTerse;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
-import static java.util.function.Predicate.not;
 import static udmi.schema.CloudModel.ModelOperation.DELETE;
 import static udmi.schema.CloudModel.ModelOperation.READ;
 import static udmi.schema.CloudModel.Resource_type.DIRECT;
@@ -42,6 +41,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.udmi.util.GeneralUtils;
 import com.google.udmi.util.JsonUtil;
+import com.google.udmi.util.MetadataMapKeys;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -288,7 +288,15 @@ public class ImplicitIotAccessProvider extends IotAccessBase {
 
     Map<String, String> map = toDeviceMap(cloudModel, timestamp);
     DataRef props = mungeDevice(registryId, deviceId, map);
-    props.entries().keySet().stream().filter(not(map::containsKey)).forEach(props::delete);
+    String udmiConfig = ifNotNullGet(cloudModel.metadata,
+        m -> m.get(MetadataMapKeys.UDMI_CONFIG));
+    if (udmiConfig == null && cloudModel.config != null) {
+      udmiConfig = stringifyTerse(cloudModel.config);
+    }
+    if (udmiConfig != null) {
+      props.put(LAST_CONFIG_KEY, udmiConfig);
+      props.put(CONFIG_VER_KEY, "1");
+    }
   }
 
   private void deleteDevice(String registryId, String deviceId, CloudModel cloudModel) {
@@ -300,6 +308,10 @@ public class ImplicitIotAccessProvider extends IotAccessBase {
       unbindGatewayDevices(registryId, deviceId);
     }
 
+    if (properties.hasSubCollections()) {
+      throw new IllegalStateException(
+          format("Cannot delete device %s/%s while sub-collections exist", registryId, deviceId));
+    }
     String gatewayId = properties.get(BOUND_TO_KEY);
     properties.entries().keySet().forEach(properties::delete);
     registryDevicesRef(registryId).delete(deviceId);
@@ -802,10 +814,13 @@ public class ImplicitIotAccessProvider extends IotAccessBase {
     DataRef dataRef = registryDeviceRef(registryId, deviceId);
     try (AutoCloseable lock = dataRef.lock()) {
       String prev = dataRef.get(CONFIG_VER_KEY);
-      if (prevVersion != null && !prevVersion.toString().equals(prev)) {
-        throw new RuntimeException("Config version update mismatch");
+      boolean versionMatch = prevVersion == null
+          || (prev == null && (prevVersion == 0L || prevVersion == 1L))
+          || (prev != null && prevVersion.toString().equals(prev));
+      if (!versionMatch) {
+        throw new RuntimeException(
+            format("Config version update mismatch: expected #%s but was #%s", prevVersion, prev));
       }
-
       String update = ofNullable(prevVersion).map(v -> v + 1)
           .orElseGet(() -> ofNullable(prev).map(Long::parseLong).orElse(1L)).toString();
 

--- a/udmis/src/main/java/com/google/bos/udmi/service/support/DataRef.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/support/DataRef.java
@@ -28,6 +28,8 @@ public abstract class DataRef {
 
   public abstract void delete(String key);
 
+  public abstract boolean hasSubCollections();
+
   /**
    * Add a device specification.
    */

--- a/udmis/src/main/java/com/google/bos/udmi/service/support/EtcdDataProvider.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/support/EtcdDataProvider.java
@@ -371,6 +371,21 @@ public class EtcdDataProvider extends ContainerBase implements IotDataProvider {
       deleteEntry(getKeyPath(key));
     }
 
+    @Override
+    public boolean hasSubCollections() {
+      checkState(deviceId != null && registryId != null,
+          "sub-collections check requires registry and device");
+      String subCollectionPrefix =
+          REGISTRY_PATH + registryId + DEVICE_PATH + deviceId + COLLECT_PATH;
+      try {
+        GetResponse response = kvClient.get(bytes(subCollectionPrefix), LIST_OPT)
+            .get(QUERY_TIMEOUT_SEC, TimeUnit.SECONDS);
+        return response.getCount() > 0;
+      } catch (Exception e) {
+        throw new RuntimeException("While checking sub-collections for " + toString(), e);
+      }
+    }
+
     public Map<String, String> entries() {
       return getEntries(getKeyPath(""));
     }

--- a/udmis/src/test/java/com/google/bos/udmi/service/access/ImplicitIotAccessProviderTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/access/ImplicitIotAccessProviderTest.java
@@ -159,6 +159,68 @@ class ImplicitIotAccessProviderTest {
         eq("/r/test-reg/d/proxy-device-4"));
   }
 
+  @Test
+  void testUpdateConfigOnNewlyCreatedDevice() {
+    CloudModel cloudModel = new CloudModel();
+    cloudModel.operation = ModelOperation.CREATE;
+    provider.modelDevice(TEST_REGISTRY, TEST_DEVICE, cloudModel, null);
+
+    udmi.schema.Envelope envelope = new udmi.schema.Envelope();
+    envelope.deviceRegistryId = TEST_REGISTRY;
+    envelope.deviceId = TEST_DEVICE;
+    String configPayload = "{\"foo\":\"bar\"}";
+    provider.updateConfig(envelope, configPayload, 1L);
+
+    Map.Entry<Long, String> fetched = provider.fetchConfig(TEST_REGISTRY, TEST_DEVICE);
+    org.junit.jupiter.api.Assertions.assertEquals(2L, fetched.getKey(),
+        "incremented version mismatch");
+    org.junit.jupiter.api.Assertions.assertEquals(configPayload, fetched.getValue(),
+        "config payload mismatch");
+  }
+
+  @Test
+  void testCreateDeviceDoesNotWipeExistingConfig() {
+    String existingConfig = "{\"existing\":true}";
+    store.put("r/test-reg/d/test-dev:last_config", existingConfig);
+    store.put("r/test-reg/d/test-dev:config_ver", "5");
+
+    CloudModel cloudModel = new CloudModel();
+    cloudModel.operation = ModelOperation.CREATE;
+    provider.modelDevice(TEST_REGISTRY, TEST_DEVICE, cloudModel, null);
+
+    Map.Entry<Long, String> fetched = provider.fetchConfig(TEST_REGISTRY, TEST_DEVICE);
+    org.junit.jupiter.api.Assertions.assertEquals(5L, fetched.getKey(),
+        "preserved config version mismatch");
+    org.junit.jupiter.api.Assertions.assertEquals(existingConfig, fetched.getValue(),
+        "preserved config payload mismatch");
+  }
+
+  @Test
+  void testCreateDeviceSeedsUdmiConfig() {
+    String seedConfig = "{\"initial\":true}";
+    CloudModel cloudModel = new CloudModel();
+    cloudModel.operation = ModelOperation.CREATE;
+    cloudModel.metadata = Map.of(com.google.udmi.util.MetadataMapKeys.UDMI_CONFIG, seedConfig);
+    provider.modelDevice(TEST_REGISTRY, TEST_DEVICE, cloudModel, null);
+
+    Map.Entry<Long, String> fetched = provider.fetchConfig(TEST_REGISTRY, TEST_DEVICE);
+    org.junit.jupiter.api.Assertions.assertEquals(1L, fetched.getKey(),
+        "seeded config version mismatch");
+    org.junit.jupiter.api.Assertions.assertEquals(seedConfig, fetched.getValue(),
+        "seeded config payload mismatch");
+  }
+
+  @Test
+  void testDeleteDeviceFailsWithExistingSubCollections() {
+    store.put("r/test-reg/d/test-dev:num_id", "12345");
+    store.put("r/test-reg/d/test-dev/c/custom_collection:entry", "some_value");
+
+    CloudModel cloudModel = new CloudModel();
+    cloudModel.operation = ModelOperation.DELETE;
+    org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+        () -> provider.modelDevice(TEST_REGISTRY, TEST_DEVICE, cloudModel, null));
+  }
+
   class FakeDataRef extends DataRef {
     private final Map<String, String> data;
 
@@ -177,6 +239,14 @@ class ImplicitIotAccessProviderTest {
     @Override
     public void delete(String key) {
       data.remove(getKeyPath(key));
+    }
+
+    @Override
+    public boolean hasSubCollections() {
+      String subCollectionPrefix = (registryId != null ? "r/" + registryId : "")
+          + (deviceId != null ? "/d/" + deviceId : "")
+          + "/c/";
+      return data.keySet().stream().anyMatch(k -> k.startsWith(subCollectionPrefix));
     }
 
     @Override


### PR DESCRIPTION
The addition of compare and swap into config updates introuced this error which was only caught when ETCD is wiped and registrar run.

TODO: Update tests because I would have expected the CI test (which starts with a fresh database) to have caught this if that was the real cause.

