### PR TITLE
hide state only devices from etcd explorer

### DIFF
--- a/udmis/src/main/java/com/google/bos/udmi/service/support/EtcdExplorerServer.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/support/EtcdExplorerServer.java
@@ -79,6 +79,7 @@ public class EtcdExplorerServer {
     return Integer.compare(s1.length(), s2.length());
   };
 
+  private static final String LAST_STATE_KEY_SUFFIX = ":last_state";
   private static final Pattern DEVICES_PATTERN =
       Pattern.compile("^/api/registries/([^/]+)/devices/?$");
   private static final Pattern PROPERTIES_PATTERN =
@@ -147,7 +148,7 @@ public class EtcdExplorerServer {
     Set<String> uniqueRegistries = new TreeSet<>(NATURAL_COMPARATOR);
     Set<String> uniqueDevices = new TreeSet<>(NATURAL_COMPARATOR);
     for (String key : keys) {
-      if (key.startsWith("/r/")) {
+      if (key.startsWith("/r/") && !key.endsWith(LAST_STATE_KEY_SUFFIX)) {
         String sub = key.substring(3);
         int slashIdx = sub.indexOf('/');
         int colonIdx = sub.indexOf(':');
@@ -181,7 +182,7 @@ public class EtcdExplorerServer {
     List<String> keys = etcdProvider.getPrefixKeys(prefix);
     Set<String> uniqueDevices = new TreeSet<>(NATURAL_COMPARATOR);
     for (String key : keys) {
-      if (key.startsWith(prefix)) {
+      if (key.startsWith(prefix) && !key.endsWith(LAST_STATE_KEY_SUFFIX)) {
         String sub = key.substring(prefix.length());
         int slashIdx = sub.indexOf('/');
         int colonIdx = sub.indexOf(':');

--- a/udmis/src/test/java/com/google/bos/udmi/service/support/EtcdExplorerServerTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/support/EtcdExplorerServerTest.java
@@ -122,9 +122,58 @@ class EtcdExplorerServerTest {
   }
 
   @Test
+  void testExcludeLastStateFromLists() throws Exception {
+    when(mockEtcdProvider.getPrefixKeys("/r/")).thenReturn(List.of(
+        "/r/cloud_iot_registry/d/AHU-1:numId",
+        "/r/cloud_iot_registry/d/AHU-1:last_state",
+        "/r/cloud_iot_registry/d/UNREGISTERED_DEV:last_state",
+        "/r/unregistered_reg/d/GHOST_DEV:last_state"
+    ));
+    when(mockEtcdProvider.getPrefixKeys("/r/cloud_iot_registry/d/")).thenReturn(List.of(
+        "/r/cloud_iot_registry/d/AHU-1:numId",
+        "/r/cloud_iot_registry/d/AHU-1:last_state",
+        "/r/cloud_iot_registry/d/UNREGISTERED_DEV:last_state"
+    ));
+
+    HttpRequest registriesReq = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl + "/api/registries"))
+        .GET()
+        .build();
+    HttpResponse<String> registriesResp =
+        httpClient.send(registriesReq, HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, registriesResp.statusCode());
+    Map<String, Object> regBody = JsonUtil.asMap(registriesResp.body());
+    System.err.println("REPRODUCTION REGISTRIES RESULT: " + regBody);
+
+    @SuppressWarnings("unchecked")
+    List<String> registries = (List<String>) regBody.get("registries");
+    assertEquals(1, registries.size(), "Unregistered registry should not be included");
+    assertEquals(1, ((Number) regBody.get("totalDevicesCount")).intValue(),
+        "Devices with only last_state should not be counted");
+    assertTrue(registries.contains("cloud_iot_registry"));
+
+    HttpRequest devicesReq = HttpRequest.newBuilder()
+        .uri(URI.create(baseUrl + "/api/registries/cloud_iot_registry/devices"))
+        .GET()
+        .build();
+    HttpResponse<String> devicesResp =
+        httpClient.send(devicesReq, HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, devicesResp.statusCode());
+    Map<String, Object> devBody = JsonUtil.asMap(devicesResp.body());
+    System.err.println("REPRODUCTION DEVICES RESULT: " + devBody);
+
+    @SuppressWarnings("unchecked")
+    List<String> devices = (List<String>) devBody.get("devices");
+    assertEquals(1, devices.size(),
+        "Unregistered device with only last_state should not be listed");
+    assertTrue(devices.contains("AHU-1"));
+  }
+
+  @Test
   void testGetProperties() throws Exception {
     when(mockEtcdProvider.getPrefixEntries("/r/cloud_iot_registry/d/AHU-1:")).thenReturn(Map.of(
-        "/r/cloud_iot_registry/d/AHU-1:numId", "12345"
+        "/r/cloud_iot_registry/d/AHU-1:numId", "12345",
+        "/r/cloud_iot_registry/d/AHU-1:last_state", "{\"timestamp\":\"2024-07-19T04:20:12Z\"}"
     ));
     when(mockEtcdProvider.getPrefixEntries("/r/cloud_iot_registry/d/AHU-1/")).thenReturn(Map.of(
         "/r/cloud_iot_registry/d/AHU-1/c/state:latest", "{\"ver\":1}"
@@ -147,7 +196,8 @@ class EtcdExplorerServerTest {
     assertNotNull(properties);
     assertEquals("12345", properties.get(":numId"));
     assertEquals("{\"ver\":1}", properties.get("/c/state:latest"));
-    assertEquals(2, properties.size(),
+    assertEquals("{\"timestamp\":\"2024-07-19T04:20:12Z\"}", properties.get(":last_state"));
+    assertEquals(3, properties.size(),
         "Properties should not include keys from AHU-10 or AHU-11: " + properties.keySet());
     verify(mockEtcdProvider).getPrefixEntries("/r/cloud_iot_registry/d/AHU-1:");
     verify(mockEtcdProvider).getPrefixEntries("/r/cloud_iot_registry/d/AHU-1/");


### PR DESCRIPTION
If a device publishes state but is not registered in etcd/mosquitto (because UDMIS is in a multiple backend perspective, and current behaviour is to persist all state messages into ETCD), then they are hidden from the explorer interface