### PR TITLE
Handle scan_addr validation errors without aborting device config generation

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
@@ -89,6 +90,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: base setup
         run: |
           bin/setup_base
@@ -139,6 +141,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: base setup
         run: bin/run_tests install_dependencies
       - name: local setup
@@ -193,6 +196,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: base setup
         run: bin/run_tests install_dependencies
       - name: local setup
@@ -250,6 +254,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: base setup
         run: |
           bin/setup_base
@@ -329,6 +334,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: base setup
         run: bin/run_tests install_dependencies
       - name: local setup
@@ -368,6 +374,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: base setup
         run: bin/run_tests install_dependencies
       - name: local setup
@@ -443,6 +450,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: Setup prerequisites
         run: |
           bin/setup_base
@@ -574,6 +582,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: Setup Base
         run: bin/setup_base
       - name: Run Bridgehead Test
@@ -612,6 +621,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
       - name: Setup Base
         run: |
           bin/setup_base

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -28,8 +30,6 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - name: Checkout source
-        uses: actions/checkout@v6
       - name: start and test local servers
         run: |
           bin/setup_base

--- a/tests/sites/metering/devices/DDC-1/expected/errors.map
+++ b/tests/sites/metering/devices/DDC-1/expected/errors.map
@@ -1,4 +1,5 @@
 Exceptions for DDC-1
+  schema validation errors
+    While converting device config
+      modbus addr 0 is invalid; must start with an alphabetical character or be a valid IPv4 address
   invalid modbus adjunct key 'bits'; allowed keys are [protocol, device, baud, parity, data_bits, stop_bits]
-  While converting device config
-    modbus addr 0 is invalid; must start with an alphabetical character or be a valid IPv4 address

--- a/tests/sites/metering/devices/DDC-1/expected/generated_config.json
+++ b/tests/sites/metering/devices/DDC-1/expected/generated_config.json
@@ -1,0 +1,16 @@
+{
+  "localnet": {
+    "families": {
+      "bacnet": {},
+      "ipv4": {},
+      "modbus": {}
+    }
+  },
+  "system": {
+    "metrics_rate_sec": 10,
+    "min_loglevel": 300,
+    "operation": {}
+  },
+  "timestamp": "2020-05-01T13:39:07Z",
+  "version": "1.5.7"
+}

--- a/tests/sites/metering/devices/EM-1/expected/errors.map
+++ b/tests/sites/metering/devices/EM-1/expected/errors.map
@@ -1,3 +1,4 @@
 Exceptions for EM-1
-  While converting device config
-    modbus addr 1 is invalid; must start with an alphabetical character or be a valid IPv4 address
+  schema validation errors
+    While converting device config
+      modbus addr 1 is invalid; must start with an alphabetical character or be a valid IPv4 address

--- a/tests/sites/metering/devices/EM-1/expected/generated_config.json
+++ b/tests/sites/metering/devices/EM-1/expected/generated_config.json
@@ -1,0 +1,31 @@
+{
+  "gateway": {
+    "target": {
+      "addr": "xxx",
+      "family": "vendor"
+    }
+  },
+  "localnet": {
+    "families": {
+      "bacnet": {},
+      "ipv4": {},
+      "modbus": {}
+    }
+  },
+  "pointset": {
+    "points": {
+      "energy_sensor": {
+        "ref": "2983",
+        "units": "kwH"
+      }
+    },
+    "sample_rate_sec": 300
+  },
+  "system": {
+    "metrics_rate_sec": 10,
+    "min_loglevel": 300,
+    "operation": {}
+  },
+  "timestamp": "2020-05-01T13:39:07Z",
+  "version": "1.5.7"
+}

--- a/tests/sites/missing/devices/AHU-22/expected/errors.map
+++ b/tests/sites/missing/devices/AHU-22/expected/errors.map
@@ -1,6 +1,16 @@
 Exceptions for AHU-22
-  While converting device config
-    bacnet scan_addr 0x65 does not match expression [1-9][0-9]*
+  schema validation errors
+    While converting device config
+      While converting point filter_differential_pressure_sensor
+        bacnet scan_addr 0x65 does not match expression [1-9][0-9]*
+    While converting device config
+      While converting point filter_alarm_pressure_status
+        bacnet scan_addr 0x65 does not match expression [1-9][0-9]*
+    While converting device config
+      bacnet scan_addr 0x65 does not match expression [1-9][0-9]*
+    While converting device config
+      While converting point filter_differential_pressure
+        bacnet scan_addr 0x65 does not match expression [1-9][0-9]*
   List of 3 exceptions
     While validating URL for point filter_differential_pressure: bacnet scan_addr 0x65 does not match expression [1-9][0-9]*
       bacnet scan_addr 0x65 does not match expression [1-9][0-9]*

--- a/tests/sites/missing/devices/AHU-22/expected/generated_config.json
+++ b/tests/sites/missing/devices/AHU-22/expected/generated_config.json
@@ -1,0 +1,37 @@
+{
+  "gateway": {
+    "target": {
+      "addr": "0x65",
+      "family": "bacnet"
+    }
+  },
+  "localnet": {
+    "families": {
+      "bacnet": {}
+    }
+  },
+  "pointset": {
+    "points": {
+      "filter_alarm_pressure_status": {
+        "ref": "MCN8.present_value",
+        "units": "No-units"
+      },
+      "filter_differential_pressure": {
+        "ref": "AI2.differential",
+        "units": "Bars"
+      },
+      "filter_differential_pressure_sensor": {
+        "ref": "FAXLE12.present_value",
+        "units": "Degrees-Celsius"
+      }
+    },
+    "sample_rate_sec": 300
+  },
+  "system": {
+    "metrics_rate_sec": 10,
+    "min_loglevel": 300,
+    "operation": {}
+  },
+  "timestamp": "2020-05-01T13:39:07Z",
+  "version": "1.5.7"
+}

--- a/validator/src/main/java/com/google/daq/mqtt/util/ConfigManager.java
+++ b/validator/src/main/java/com/google/daq/mqtt/util/ConfigManager.java
@@ -176,7 +176,7 @@ public class ConfigManager {
       String family = target.family;
       String localAddr = ifNotNullGet(family, this::getLocalnetAddr);
       String gatewayAddr = target.addr;
-      catchIfSchemaViolation(
+      captureSchemaViolation(
               format("%s gateway target", family),
           () -> checkState(localAddr == null || gatewayAddr == null,
               format("both gateway.target.addr and localnet.families.%s.addr should not be defined",
@@ -194,7 +194,7 @@ public class ConfigManager {
     throw new RuntimeException("Unknown protocol family: " + family);
   }
 
-  private void catchIfSchemaViolation(String description, Runnable action) {
+  private void captureSchemaViolation(String description, Runnable action) {
     try {
       action.run();
     } catch (Exception e) {
@@ -210,7 +210,7 @@ public class ConfigManager {
         && metadata.gateway.target != null
         && Boolean.TRUE.equals(metadata.gateway.target.vendor_ref);
     if (!isVendorRef && addr != null) {
-      catchIfSchemaViolation(
+      captureSchemaViolation(
           format("%s localnet addr", family),
           () -> getFamilyProvider(family).validateAddr(addr));
     }
@@ -224,7 +224,7 @@ public class ConfigManager {
         && metadata.gateway.target != null
         && Boolean.TRUE.equals(metadata.gateway.target.vendor_ref);
     if (!isVendorRef && addr != null) {
-      catchIfSchemaViolation(
+      captureSchemaViolation(
           format("%s localnet network", family),
           () -> getFamilyProvider(family).validateNetwork(addr));
     }
@@ -293,7 +293,7 @@ public class ConfigManager {
         && metadata.gateway.target != null
         && Boolean.TRUE.equals(metadata.gateway.target.vendor_ref);
     if (!isVendorRef) {
-      catchIfSchemaViolation(
+      captureSchemaViolation(
           format("%s %s", family, pointRef),
           () -> {
             String fullRef = pointRef.contains("://") ? pointRef

--- a/validator/src/main/java/com/google/daq/mqtt/util/ConfigManager.java
+++ b/validator/src/main/java/com/google/daq/mqtt/util/ConfigManager.java
@@ -175,13 +175,24 @@ public class ConfigManager {
       String family = target.family;
       String localAddr = ifNotNullGet(family, this::getLocalnetAddr);
       String gatewayAddr = target.addr;
-      checkState(localAddr == null || gatewayAddr == null,
-          format("both gateway.target.addr and localnet.families.%s.addr should not be defined",
-              family));
+      catchIfSchemaViolation(
+              format("%s gateway target", family),
+          () -> checkState(localAddr == null || gatewayAddr == null,
+              format("both gateway.target.addr and localnet.families.%s.addr should not be defined",
+                  family)));
       configVar.target.addr = ofNullable(localAddr).orElse(gatewayAddr);
     });
 
     return gatewayConfig;
+  }
+
+  private void catchIfSchemaViolation(String description, Runnable action) {
+    try {
+      action.run();
+    } catch (Exception e) {
+      schemaViolationsMap.put(String.format("%s: %s", description, getCurrentContext()),
+          wrapExceptionWithContext(e, false));
+    }
   }
 
   private String getLocalnetAddr(String rawFamily) {
@@ -190,8 +201,16 @@ public class ConfigManager {
     boolean isVendorRef = metadata.gateway != null
         && metadata.gateway.target != null
         && Boolean.TRUE.equals(metadata.gateway.target.vendor_ref);
-    if (!isVendorRef) {
-      ifNotNullThen(addr, a -> NAMED_FAMILIES.get(family).validateAddr(a));
+    if (!isVendorRef && addr != null) {
+      catchIfSchemaViolation(
+          format("%s localnet addr", family),
+          () -> {
+            if (NAMED_FAMILIES.containsKey(family)) {
+              NAMED_FAMILIES.get(family).validateAddr(addr);
+            } else {
+              throw new RuntimeException("Unknown protocol family: " + family);
+            }
+          });
     }
     return addr;
   }
@@ -202,8 +221,16 @@ public class ConfigManager {
     boolean isVendorRef = metadata.gateway != null
         && metadata.gateway.target != null
         && Boolean.TRUE.equals(metadata.gateway.target.vendor_ref);
-    if (!isVendorRef) {
-      ifNotNullThen(addr, a -> NAMED_FAMILIES.get(family).validateNetwork(addr));
+    if (!isVendorRef && addr != null) {
+      catchIfSchemaViolation(
+          format("%s localnet network", family),
+          () -> {
+            if (NAMED_FAMILIES.containsKey(family)) {
+              NAMED_FAMILIES.get(family).validateNetwork(addr);
+            } else {
+              throw new RuntimeException("Unknown protocol family: " + family);
+            }
+          });
     }
     return addr;
   }
@@ -270,23 +297,22 @@ public class ConfigManager {
         && metadata.gateway.target != null
         && Boolean.TRUE.equals(metadata.gateway.target.vendor_ref);
     if (!isVendorRef) {
-      try {
-        String fullRef = pointRef.contains("://") ? pointRef
-            : constructUrl(family, localAddr, pointRef);
-        String targetFamily = "vendor";
-        if (fullRef.contains("://")) {
-          targetFamily = fullRef.substring(0, fullRef.indexOf("://"));
-        }
+      catchIfSchemaViolation(
+          format("%s %s", family, pointRef),
+          () -> {
+            String fullRef = pointRef.contains("://") ? pointRef
+                : constructUrl(family, localAddr, pointRef);
+            String targetFamily = "vendor";
+            if (fullRef.contains("://")) {
+              targetFamily = fullRef.substring(0, fullRef.indexOf("://"));
+            }
 
-        if (NAMED_FAMILIES.containsKey(targetFamily)) {
-          NAMED_FAMILIES.get(targetFamily).validateUrl(fullRef);
-        } else {
-          throw new RuntimeException("Unknown protocol family in URL: " + targetFamily);
-        }
-      } catch (Exception e) {
-        schemaViolationsMap.put(String.format("%s %s: %s", family, pointRef, getCurrentContext()),
-            wrapExceptionWithContext(e, false));
-      }
+            if (NAMED_FAMILIES.containsKey(targetFamily)) {
+              NAMED_FAMILIES.get(targetFamily).validateUrl(fullRef);
+            } else {
+              throw new RuntimeException("Unknown protocol family in URL: " + targetFamily);
+            }
+          });
     }
     return pointRef;
   }

--- a/validator/src/main/java/com/google/daq/mqtt/util/ConfigManager.java
+++ b/validator/src/main/java/com/google/daq/mqtt/util/ConfigManager.java
@@ -18,6 +18,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
 import com.google.common.collect.ImmutableList;
+import com.google.daq.mqtt.util.providers.FamilyProvider;
 import com.google.udmi.util.ExceptionList;
 import com.google.udmi.util.SiteModel;
 import java.io.File;
@@ -186,6 +187,13 @@ public class ConfigManager {
     return gatewayConfig;
   }
 
+  private FamilyProvider getFamilyProvider(String family) {
+    if (NAMED_FAMILIES.containsKey(family)) {
+      return NAMED_FAMILIES.get(family);
+    }
+    throw new RuntimeException("Unknown protocol family: " + family);
+  }
+
   private void catchIfSchemaViolation(String description, Runnable action) {
     try {
       action.run();
@@ -204,13 +212,7 @@ public class ConfigManager {
     if (!isVendorRef && addr != null) {
       catchIfSchemaViolation(
           format("%s localnet addr", family),
-          () -> {
-            if (NAMED_FAMILIES.containsKey(family)) {
-              NAMED_FAMILIES.get(family).validateAddr(addr);
-            } else {
-              throw new RuntimeException("Unknown protocol family: " + family);
-            }
-          });
+          () -> getFamilyProvider(family).validateAddr(addr));
     }
     return addr;
   }
@@ -224,13 +226,7 @@ public class ConfigManager {
     if (!isVendorRef && addr != null) {
       catchIfSchemaViolation(
           format("%s localnet network", family),
-          () -> {
-            if (NAMED_FAMILIES.containsKey(family)) {
-              NAMED_FAMILIES.get(family).validateNetwork(addr);
-            } else {
-              throw new RuntimeException("Unknown protocol family: " + family);
-            }
-          });
+          () -> getFamilyProvider(family).validateNetwork(addr));
     }
     return addr;
   }
@@ -307,11 +303,7 @@ public class ConfigManager {
               targetFamily = fullRef.substring(0, fullRef.indexOf("://"));
             }
 
-            if (NAMED_FAMILIES.containsKey(targetFamily)) {
-              NAMED_FAMILIES.get(targetFamily).validateUrl(fullRef);
-            } else {
-              throw new RuntimeException("Unknown protocol family in URL: " + targetFamily);
-            }
+            getFamilyProvider(targetFamily).validateUrl(fullRef);
           });
     }
     return pointRef;

--- a/validator/src/test/java/com/google/daq/mqtt/registrar/RegistrarTest.java
+++ b/validator/src/test/java/com/google/daq/mqtt/registrar/RegistrarTest.java
@@ -19,6 +19,7 @@ import static com.google.udmi.util.SiteModel.MOCK_CLEAN;
 import static com.google.udmi.util.SiteModel.MOCK_PROJECT;
 import static java.lang.Boolean.TRUE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -30,6 +31,7 @@ import com.google.daq.mqtt.util.IotMockProvider.ActionType;
 import com.google.daq.mqtt.util.IotMockProvider.MockAction;
 import com.google.udmi.util.ExceptionMap.ExceptionCategory;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +40,8 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import udmi.schema.CloudModel;
+import udmi.schema.FamilyLocalnetModel;
+import udmi.schema.LocalnetModel;
 import udmi.schema.Metadata;
 import udmi.schema.PointPointsetModel;
 
@@ -219,6 +223,31 @@ public class RegistrarTest {
     assertEquals("bind devices", ImmutableSet.of("AHU-22"),
         bindActions.stream().map(action -> action.deviceId).collect(
             Collectors.toSet()));
+  }
+
+  @Test
+  public void scanAddrMismatchHandlingTest() {
+    Registrar registrar = getRegistrar(ImmutableList.of());
+    registrar.execute(() -> {
+      Map<String, LocalDevice> localDevices = registrar.getWorkingDevices();
+      LocalDevice device = localDevices.get(DEVICE_ID);
+      Metadata metadata = device.getMetadata();
+      if (metadata.localnet == null) {
+        metadata.localnet = new LocalnetModel();
+      }
+      if (metadata.localnet.families == null) {
+        metadata.localnet.families = new HashMap<>();
+      }
+      FamilyLocalnetModel familyModel = new FamilyLocalnetModel();
+      familyModel.addr = "2C:58:B9:6C:7A:88"; // Uppercase MAC address
+      metadata.localnet.families.put("ether", familyModel);
+    });
+
+    LocalDevice device = registrar.getWorkingDevices().get(DEVICE_ID);
+    assertNotNull("Generated config should exist despite scan_addr validation error",
+        device.getSettings().config);
+    assertTrue("Device should record schema violation for scan_addr mismatch",
+        device.hasCategory(ExceptionCategory.schema));
   }
 
   private Boolean isNotBlocking(MockAction action) {


### PR DESCRIPTION
- Catch validation exceptions in ConfigManager for `scan_addr` and target references and record them into schemaViolationsMap.
- Ensure `generated_config.json` is still created while reporting schema violations.
- Add `scanAddrMismatchHandlingTest` unit test in `RegistrarTest`.