### PR TITLE
fix mqtt->pubsub bridge failure conditions

### DIFF
--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -102,6 +102,9 @@ public class MqttToPubSubBridge {
       .maximumSize(10000)
       .build();
 
+  /**
+   * Represents the state of an unacknowledged MQTT message.
+   */
   public enum UnackedState {
     IN_PROCESS,
     ABANDONED
@@ -161,7 +164,8 @@ public class MqttToPubSubBridge {
               fullStartTime = System.currentTimeMillis();
             } else if (System.currentTimeMillis() - fullStartTime >= 300000) {
               tripped = true;
-              logger.error("Unacked message threshold exceeded for 300 seconds! Tripping circuit breaker.");
+              logger.error(
+                  "Unacked message threshold exceeded for 300 seconds! Tripping circuit breaker.");
               try {
                 mqttClient.disconnect();
               } catch (Exception e) {
@@ -190,10 +194,13 @@ public class MqttToPubSubBridge {
         try {
           // Jitter: +/- 50% random delay around baseIntervalSec
           int jitterSec = (int) (baseIntervalSec * 0.5);
-          int delaySec = baseIntervalSec + (jitterSec > 0 ? (random.nextInt(jitterSec * 2 + 1) - jitterSec) : 0);
+          int delaySec = baseIntervalSec
+              + (jitterSec > 0 ? (random.nextInt(jitterSec * 2 + 1) - jitterSec) : 0);
           Thread.sleep(Math.max(1, delaySec) * 1000L);
           if (mqttClient.isConnected() && !tripped) {
-            logger.info("Executing scheduled reconnect (interval: {}s) to rebalance shared subscription...", delaySec);
+            logger.info(
+                "Executing scheduled reconnect (interval: {}s) to rebalance shared subscription...",
+                delaySec);
             try {
               mqttClient.disconnect();
             } catch (Exception e) {
@@ -515,17 +522,22 @@ public class MqttToPubSubBridge {
             try {
               if (message.isDuplicate()) {
                 int currentDups = dupCount.incrementAndGet();
-                logger.info("Received DUP MQTT message (DUP=true, ID {}). Total DUP messages tracked: {}",
+                logger.info(
+                    "Received DUP MQTT message (DUP=true, ID {}). Total DUP messages tracked: {}",
                     message.getId(), currentDups);
               }
 
               if (unackedMessages.get(message.getId()) == UnackedState.IN_PROCESS) {
                 if (message.isDuplicate()) {
-                  logger.warn("MQTT message ID {} is already IN_PROCESS. Skipping queue to avoid duplicate processing.",
+                  logger.warn(
+                      "MQTT message ID {} is already IN_PROCESS."
+                          + " Skipping queue to avoid duplicate processing.",
                       message.getId());
                   return;
                 } else {
-                  logger.warn("MQTT message ID {} is already IN_PROCESS but DUP flag is false (ID wrap-around). Processing new message.",
+                  logger.warn(
+                      "MQTT message ID {} is already IN_PROCESS but DUP flag is false"
+                          + " (ID wrap-around). Processing new message.",
                       message.getId());
                 }
               }
@@ -647,11 +659,13 @@ public class MqttToPubSubBridge {
 
         @Override
         public void onFailure(Throwable t) {
-          handlePublishFailure(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt, t);
+          handlePublishFailure(
+              publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt, t);
         }
       }, MoreExecutors.directExecutor());
     } catch (Exception e) {
-      handlePublishFailure(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt, e);
+      handlePublishFailure(
+          publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt, e);
     }
   }
 
@@ -666,7 +680,9 @@ public class MqttToPubSubBridge {
         publishWithRetry(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt + 1);
       }, backoffMs, TimeUnit.MILLISECONDS);
     } else {
-      logger.error("Failed to publish to Pub/Sub after 5 attempts. Marking message ID {} as ABANDONED (unacked).",
+      logger.error(
+          "Failed to publish to Pub/Sub after 5 attempts."
+              + " Marking message ID {} as ABANDONED (unacked).",
           mqttMessage.getId(), t);
       unackedMessages.put(mqttMessage.getId(), UnackedState.ABANDONED);
     }

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -38,7 +38,9 @@ import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -106,6 +108,7 @@ public class MqttToPubSubBridge {
   }
 
   private final ThreadPoolExecutor executor;
+  private final ScheduledExecutorService retryScheduler;
   private volatile boolean tripped = false;
   private final ConcurrentMap<Integer, UnackedState> unackedMessages = new ConcurrentHashMap<>();
   private final AtomicInteger dupCount = new AtomicInteger(0);
@@ -133,6 +136,8 @@ public class MqttToPubSubBridge {
         new ArrayBlockingQueue<>(MAX_QUEUE_SIZE),
         new ThreadFactoryBuilder().setNameFormat("mqtt-bridge-%d").setDaemon(true).build(),
         new ThreadPoolExecutor.AbortPolicy());
+    this.retryScheduler = Executors.newScheduledThreadPool(4,
+        new ThreadFactoryBuilder().setNameFormat("mqtt-bridge-retry-%d").setDaemon(true).build());
   }
 
   /**
@@ -187,19 +192,17 @@ public class MqttToPubSubBridge {
           int jitterSec = (int) (baseIntervalSec * 0.5);
           int delaySec = baseIntervalSec + (jitterSec > 0 ? (random.nextInt(jitterSec * 2 + 1) - jitterSec) : 0);
           Thread.sleep(Math.max(1, delaySec) * 1000L);
-          synchronized (mqttClient) {
-            if (mqttClient.isConnected() && !tripped) {
-              logger.info("Executing scheduled reconnect (interval: {}s) to rebalance shared subscription...", delaySec);
-              try {
-                mqttClient.disconnect();
-              } catch (Exception e) {
-                logger.warn("Error disconnecting for scheduled reconnect", e);
-              }
-              try {
-                mqttClient.reconnect();
-              } catch (Exception e) {
-                logger.warn("Error reconnecting during scheduled reconnect", e);
-              }
+          if (mqttClient.isConnected() && !tripped) {
+            logger.info("Executing scheduled reconnect (interval: {}s) to rebalance shared subscription...", delaySec);
+            try {
+              mqttClient.disconnect();
+            } catch (Exception e) {
+              logger.warn("Error disconnecting for scheduled reconnect", e);
+            }
+            try {
+              mqttClient.reconnect();
+            } catch (Exception e) {
+              logger.warn("Error reconnecting during scheduled reconnect", e);
             }
           }
         } catch (InterruptedException e) {
@@ -517,14 +520,20 @@ public class MqttToPubSubBridge {
               }
 
               if (unackedMessages.get(message.getId()) == UnackedState.IN_PROCESS) {
-                logger.warn("MQTT message ID {} is already IN_PROCESS. Skipping queue to avoid duplicate processing.",
-                    message.getId());
-                return;
+                if (message.isDuplicate()) {
+                  logger.warn("MQTT message ID {} is already IN_PROCESS. Skipping queue to avoid duplicate processing.",
+                      message.getId());
+                  return;
+                } else {
+                  logger.warn("MQTT message ID {} is already IN_PROCESS but DUP flag is false (ID wrap-around). Processing new message.",
+                      message.getId());
+                }
               }
               unackedMessages.put(message.getId(), UnackedState.IN_PROCESS);
 
               final String receiveTime = java.time.Instant.now().toString();
               executor.submit(() -> {
+                boolean publishInitiated = false;
                 try {
                   byte[] payload = message.getPayload();
                   logger.debug("MQTT Message Received - Topic: {}, Payload Length: {}",
@@ -583,17 +592,26 @@ public class MqttToPubSubBridge {
 
                   // Publish with 5x retry + exponential backoff
                   publishWithRetry(publisher, pubsubMessage, message, topic, mqttClient, 1);
-
-                } catch (RuntimeException e) {
+                  publishInitiated = true;
+                } catch (Exception e) {
                   logger.warn("Error processing MQTT message", e);
+                } finally {
+                  if (!publishInitiated) {
+                    unackedMessages.remove(message.getId());
+                  }
                 }
               });
-            } catch (RejectedExecutionException e) {
-              logger.error("Execution rejected, queue full! Dropping MQTT connection.", e);
-              try {
-                mqttClient.disconnectForcibly();
-              } catch (MqttException me) {
-                logger.error("Error while forcing disconnect", me);
+            } catch (Exception e) {
+              unackedMessages.remove(message.getId());
+              if (e instanceof RejectedExecutionException) {
+                logger.error("Execution rejected, queue full! Dropping MQTT connection.", e);
+                try {
+                  mqttClient.disconnectForcibly();
+                } catch (MqttException me) {
+                  logger.error("Error while forcing disconnect", me);
+                }
+              } else {
+                logger.error("Error submitting message to executor", e);
               }
             }
           }
@@ -612,41 +630,46 @@ public class MqttToPubSubBridge {
 
   private void publishWithRetry(Publisher publisher, PubsubMessage pubsubMessage,
       MqttMessage mqttMessage, String topic, IMqttClient mqttClient, int attempt) {
-    ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
-    ApiFutures.addCallback(messageIdFuture, new ApiFutureCallback<String>() {
-      @Override
-      public void onSuccess(String msgId) {
-        logger.debug("Published to Pub/Sub with message ID: {}", msgId);
-        unackedMessages.remove(mqttMessage.getId());
-        try {
-          mqttClient.messageArrivedComplete(mqttMessage.getId(), mqttMessage.getQos());
-        } catch (MqttException e) {
-          logger.error("Failed to ACK MQTT message, it will be redelivered", e);
+    try {
+      ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
+      ApiFutures.addCallback(messageIdFuture, new ApiFutureCallback<String>() {
+        @Override
+        public void onSuccess(String msgId) {
+          logger.debug("Published to Pub/Sub with message ID: {}", msgId);
+          unackedMessages.remove(mqttMessage.getId());
+          unackedMessages.entrySet().removeIf(entry -> entry.getValue() == UnackedState.ABANDONED);
+          try {
+            mqttClient.messageArrivedComplete(mqttMessage.getId(), mqttMessage.getQos());
+          } catch (MqttException e) {
+            logger.error("Failed to ACK MQTT message, it will be redelivered", e);
+          }
         }
-      }
 
-      @Override
-      public void onFailure(Throwable t) {
-        if (attempt < 5 && !tripped) {
-          long baseMs = (1L << (attempt - 1)) * 800L;
-          int backoffMs = (int) baseMs + random.nextInt((int) (baseMs * 0.5));
-          logger.warn("Error publishing to Pub/Sub (attempt {}/5), retrying in {}ms...",
-              attempt, backoffMs, t);
-          executor.submit(() -> {
-            try {
-              Thread.sleep(backoffMs);
-              publishWithRetry(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt + 1);
-            } catch (InterruptedException ie) {
-              Thread.currentThread().interrupt();
-            }
-          });
-        } else {
-          logger.error("Failed to publish to Pub/Sub after 5 attempts. Marking message ID {} as ABANDONED (unacked).",
-              mqttMessage.getId(), t);
-          unackedMessages.put(mqttMessage.getId(), UnackedState.ABANDONED);
+        @Override
+        public void onFailure(Throwable t) {
+          handlePublishFailure(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt, t);
         }
-      }
-    }, MoreExecutors.directExecutor());
+      }, MoreExecutors.directExecutor());
+    } catch (Exception e) {
+      handlePublishFailure(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt, e);
+    }
+  }
+
+  private void handlePublishFailure(Publisher publisher, PubsubMessage pubsubMessage,
+      MqttMessage mqttMessage, String topic, IMqttClient mqttClient, int attempt, Throwable t) {
+    if (attempt < 5 && !tripped) {
+      long baseMs = (1L << (attempt - 1)) * 800L;
+      int backoffMs = (int) baseMs + random.nextInt((int) (baseMs * 0.5));
+      logger.warn("Error publishing to Pub/Sub (attempt {}/5), retrying in {}ms...",
+          attempt, backoffMs, t);
+      retryScheduler.schedule(() -> {
+        publishWithRetry(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt + 1);
+      }, backoffMs, TimeUnit.MILLISECONDS);
+    } else {
+      logger.error("Failed to publish to Pub/Sub after 5 attempts. Marking message ID {} as ABANDONED (unacked).",
+          mqttMessage.getId(), t);
+      unackedMessages.put(mqttMessage.getId(), UnackedState.ABANDONED);
+    }
   }
 
   private static SSLSocketFactory getSocketFactory(
@@ -807,5 +830,10 @@ public class MqttToPubSubBridge {
       numIdCache.put(cacheKey, ""); // Cache empty string for negative lookups
       return null;
     }
+  }
+
+  public void shutdown() {
+    executor.shutdown();
+    retryScheduler.shutdown();
   }
 }

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -96,6 +96,16 @@ public class MqttToPubSubBridge {
 
   private static final int MAX_QUEUE_SIZE = 1000;
   private static final int NUM_THREADS = 24;
+  public static final int DEFAULT_UNACKED_THRESHOLD = 100;
+  public static final long DEFAULT_CIRCUIT_BREAKER_TIMEOUT_MS = 300000L; // 5 minutes
+
+  /**
+   * Represents the lifecycle state of an unacknowledged MQTT message.
+   */
+  public enum MessageState {
+    IN_PROCESS,
+    ABANDONED
+  }
 
   private static final Cache<String, String> numIdCache = CacheBuilder.newBuilder()
       .expireAfterWrite(1, TimeUnit.MINUTES)
@@ -105,17 +115,33 @@ public class MqttToPubSubBridge {
   private final ThreadPoolExecutor executor;
   private final ScheduledExecutorService retryScheduler;
   private volatile boolean tripped = false;
-  private final Set<String> unackedMessages = ConcurrentHashMap.newKeySet();
+  private final ConcurrentHashMap<String, MessageState> unackedMessages = new ConcurrentHashMap<>();
   private final Random random = new Random();
 
   public int getUnackedCount() {
     return unackedMessages.size();
   }
 
-  static String getMessageHash(MqttMessage message) {
+  public int getInProcessCount() {
+    return (int) unackedMessages.values().stream().filter(s -> s == MessageState.IN_PROCESS).count();
+  }
+
+  public int getAbandonedCount() {
+    return (int) unackedMessages.values().stream().filter(s -> s == MessageState.ABANDONED).count();
+  }
+
+  public MessageState getMessageState(String messageKey) {
+    return unackedMessages.get(messageKey);
+  }
+
+  static String getMessageHash(String topic, MqttMessage message) {
     byte[] payload = message.getPayload() != null ? message.getPayload() : new byte[0];
     String payloadHash = Hashing.murmur3_128().hashBytes(payload).toString();
-    return message.getId() + ":" + payloadHash;
+    return (topic != null && !topic.isEmpty() ? topic + ":" : "") + message.getId() + ":" + payloadHash;
+  }
+
+  static String getMessageHash(MqttMessage message) {
+    return getMessageHash("", message);
   }
 
   static void clearCacheForTest() {
@@ -150,24 +176,30 @@ public class MqttToPubSubBridge {
   }
 
   private void startCircuitBreaker(IMqttClient mqttClient) {
+    startCircuitBreaker(mqttClient, DEFAULT_UNACKED_THRESHOLD, DEFAULT_CIRCUIT_BREAKER_TIMEOUT_MS);
+  }
+
+  void startCircuitBreaker(IMqttClient mqttClient, int threshold, long timeoutMs) {
     Thread monitor = new Thread(() -> {
       long fullStartTime = 0;
       while (!tripped) {
         try {
           Thread.sleep(1000);
-          // Check if unacked inflight messages exceed threshold (50 out of RECEIVE_MAXIMUM = 100)
-          if (unackedMessages.size() >= 50) {
+          // Check if total unacked messages (IN_PROCESS + ABANDONED) exceed threshold
+          if (unackedMessages.size() >= threshold) {
             if (fullStartTime == 0) {
               fullStartTime = System.currentTimeMillis();
-            } else if (System.currentTimeMillis() - fullStartTime >= 300000) {
+            } else if (System.currentTimeMillis() - fullStartTime >= timeoutMs) {
               tripped = true;
               logger.error(
-                  "Unacked message threshold exceeded for 300 seconds! Tripping circuit breaker.");
+                  "Unacked message threshold ({} messages) exceeded for {}ms! Tripping circuit breaker.",
+                  threshold, timeoutMs);
               try {
                 mqttClient.disconnect();
               } catch (Exception e) {
                 logger.error("Error disconnecting during circuit breaker trip", e);
               }
+              exit(1);
             }
           } else {
             fullStartTime = 0; // reset
@@ -179,7 +211,12 @@ public class MqttToPubSubBridge {
       }
     });
     monitor.setDaemon(true);
+    monitor.setName("mqtt-circuit-breaker");
     monitor.start();
+  }
+
+  protected void exit(int status) {
+    System.exit(status);
   }
 
   private void startPeriodicReconnect(IMqttClient mqttClient, int baseIntervalSec) {
@@ -206,7 +243,8 @@ public class MqttToPubSubBridge {
             try {
               mqttClient.reconnect();
             } catch (Exception e) {
-              logger.warn("Error reconnecting during scheduled reconnect", e);
+              logger.error("FATAL: Error reconnecting during scheduled reconnect. Exiting for K8s restart.", e);
+              exit(1);
             }
           }
         } catch (InterruptedException e) {
@@ -276,6 +314,7 @@ public class MqttToPubSubBridge {
     Publisher publisher = null;
     IMqttClient mqttClient = null;
     EtcdDataProvider etcdProvider = null;
+    MqttToPubSubBridge bridge = null;
 
     try {
       etcdProvider = createEtcdProvider(etcdTarget, etcdOptions);
@@ -308,7 +347,7 @@ public class MqttToPubSubBridge {
       mqttClient.connect(connOpts);
       logger.debug("Connected to MQTT broker.");
 
-      MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+      bridge = new MqttToPubSubBridge();
 
       // Start the circuit breaker monitor
       bridge.startCircuitBreaker(mqttClient);
@@ -331,12 +370,22 @@ public class MqttToPubSubBridge {
 
     } catch (MqttException e) {
       logger.error("MQTT Error", e);
+      System.exit(1);
     } catch (IOException e) {
       logger.error("Pub/Sub Error", e);
+      System.exit(1);
     } catch (Exception e) {
       logger.error("An unexpected error occurred", e);
+      System.exit(1);
     } finally {
       // Shutdown
+      if (bridge != null) {
+        try {
+          bridge.shutdown();
+        } catch (Exception e) {
+          logger.warn("Error shutting down bridge executors", e);
+        }
+      }
       if (etcdProvider != null) {
         try {
           etcdProvider.shutdown();
@@ -360,6 +409,9 @@ public class MqttToPubSubBridge {
         } catch (Exception e) {
           logger.warn("Error shutting down Pub/Sub publisher", e);
         }
+      }
+      if (bridge != null && bridge.isTripped()) {
+        System.exit(1);
       }
     }
   }
@@ -521,25 +573,40 @@ public class MqttToPubSubBridge {
           @Override
           public void messageArrived(String topic, MqttMessage message) {
             if (tripped) {
-              // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+              // ABORT REQUEST RECEIVED, ABANDON REQUESTS
               return;
             }
             String messageKey = null;
             try {
-              messageKey = getMessageHash(message);
-              if (!unackedMessages.add(messageKey)) {
+              messageKey = getMessageHash(topic, message);
+              final String finalMessageKey = messageKey;
+
+              final java.util.concurrent.atomic.AtomicBoolean shouldProcess =
+                  new java.util.concurrent.atomic.AtomicBoolean(false);
+
+              unackedMessages.compute(finalMessageKey, (key, existingState) -> {
+                if (existingState == MessageState.IN_PROCESS) {
+                  // Message is currently in-flight, skip queue
+                  return MessageState.IN_PROCESS;
+                }
+                // New message (existingState == null) OR previously ABANDONED
+                // Transition to IN_PROCESS and process
+                shouldProcess.set(true);
+                return MessageState.IN_PROCESS;
+              });
+
+              if (!shouldProcess.get()) {
                 logger.warn(
-                    "MQTT message ID {} (hash: {}) is already in process."
+                    "MQTT message ID {} (key: {}) is already in process."
                             + " Skipping queue to avoid duplicate processing.",
-                    message.getId(), messageKey);
+                    message.getId(), finalMessageKey);
                 return;
               }
 
-              final String finalMessageKey = messageKey;
               final String receiveTime = java.time.Instant.now().toString();
               executor.submit(() -> {
                 if (tripped) {
-                  // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+                  // ABORT REQUEST RECEIVED, ABANDON REQUESTS
                   return;
                 }
                 boolean publishInitiated = false;
@@ -600,7 +667,7 @@ public class MqttToPubSubBridge {
                       pubsubMessageBuilder.putAllAttributes(attributes).build();
 
                   // Publish with 5x retry + exponential backoff
-                  publishWithRetry(publisher, pubsubMessage, message, topic, mqttClient, 1);
+                  publishWithRetry(publisher, pubsubMessage, message, finalMessageKey, topic, mqttClient, 1);
                   publishInitiated = true;
                 } catch (Exception e) {
                   logger.warn("Error processing MQTT message", e);
@@ -640,9 +707,9 @@ public class MqttToPubSubBridge {
   }
 
   private void publishWithRetry(Publisher publisher, PubsubMessage pubsubMessage,
-      MqttMessage mqttMessage, String topic, IMqttClient mqttClient, int attempt) {
+      MqttMessage mqttMessage, String messageKey, String topic, IMqttClient mqttClient, int attempt) {
     if (tripped) {
-      // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+      // ABORT REQUEST RECEIVED, ABANDON REQUESTS
       return;
     }
     try {
@@ -651,11 +718,11 @@ public class MqttToPubSubBridge {
         @Override
         public void onSuccess(String msgId) {
           if (tripped) {
-            // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+            // ABORT REQUEST RECEIVED, ABANDON REQUESTS
             return;
           }
           logger.debug("Published to Pub/Sub with message ID: {}", msgId);
-          unackedMessages.remove(getMessageHash(mqttMessage));
+          unackedMessages.remove(messageKey);
           try {
             mqttClient.messageArrivedComplete(mqttMessage.getId(), mqttMessage.getQos());
           } catch (MqttException e) {
@@ -666,17 +733,17 @@ public class MqttToPubSubBridge {
         @Override
         public void onFailure(Throwable t) {
           handlePublishFailure(
-              publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt, t);
+              publisher, pubsubMessage, mqttMessage, messageKey, topic, mqttClient, attempt, t);
         }
       }, MoreExecutors.directExecutor());
     } catch (Exception e) {
       handlePublishFailure(
-          publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt, e);
+          publisher, pubsubMessage, mqttMessage, messageKey, topic, mqttClient, attempt, e);
     }
   }
 
   private void handlePublishFailure(Publisher publisher, PubsubMessage pubsubMessage,
-      MqttMessage mqttMessage, String topic, IMqttClient mqttClient, int attempt, Throwable t) {
+      MqttMessage mqttMessage, String messageKey, String topic, IMqttClient mqttClient, int attempt, Throwable t) {
     if (attempt < 5 && !tripped) {
       long baseMs = (1L << (attempt - 1)) * 800L;
       int backoffMs = (int) baseMs + random.nextInt((int) (baseMs * 0.5));
@@ -684,17 +751,17 @@ public class MqttToPubSubBridge {
           attempt, backoffMs, t);
       retryScheduler.schedule(() -> {
         if (tripped) {
-          // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+          // ABORT REQUEST RECEIVED, ABANDON REQUESTS
           return;
         }
-        publishWithRetry(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt + 1);
+        publishWithRetry(publisher, pubsubMessage, mqttMessage, messageKey, topic, mqttClient, attempt + 1);
       }, backoffMs, TimeUnit.MILLISECONDS);
     } else {
       logger.error(
           "Failed to publish to Pub/Sub after 5 attempts."
-              + " Leaving message ID {} unacked.",
-              mqttMessage.getId(), t);
-      unackedMessages.remove(getMessageHash(mqttMessage));
+              + " Leaving message ID {} unacked (marked as ABANDONED).",
+          mqttMessage.getId(), t);
+      unackedMessages.put(messageKey, MessageState.ABANDONED);
     }
   }
 

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -94,6 +94,11 @@ public class MqttToPubSubBridge {
   private static final Pattern TOPIC_PATTERN = Pattern.compile("/r/([^/]+)/d/([^/]+)/?(.*)");
   private static final Logger logger = LoggerFactory.getLogger(MqttToPubSubBridge.class);
 
+  // Maximum capacity for the in-memory executor task queue.
+  // This acts as a defensive 10x safety buffer above MQTT v5 Receive Maximum (100).
+  // Under normal MQTT v5 operation, the broker throttles delivery to at most 100 in-flight
+  // unacknowledged messages, so this 1000-element queue is a defensive precaution for bursts,
+  // QoS 0 traffic, or MQTT v3.1.1 fallback.
   private static final int MAX_QUEUE_SIZE = 1000;
   private static final int NUM_THREADS = 24;
   public static final int DEFAULT_UNACKED_THRESHOLD = 100;
@@ -172,7 +177,11 @@ public class MqttToPubSubBridge {
   }
 
   void putMessageRecordForTest(String messageKey, MessageRecord record) {
-    unackedMessages.put(messageKey, record);
+    if (record == null) {
+      unackedMessages.remove(messageKey);
+    } else {
+      unackedMessages.put(messageKey, record);
+    }
   }
 
   static String getMessageHash(String topic, MqttMessage message) {
@@ -199,7 +208,22 @@ public class MqttToPubSubBridge {
         0L, TimeUnit.MILLISECONDS,
         new ArrayBlockingQueue<>(MAX_QUEUE_SIZE),
         new ThreadFactoryBuilder().setNameFormat("mqtt-bridge-%d").setDaemon(true).build(),
-        new ThreadPoolExecutor.AbortPolicy());
+        (runnable, exec) -> {
+          if (exec.isShutdown()) {
+            throw new RejectedExecutionException("Executor is shut down");
+          }
+          try {
+            // Block up to 2 seconds to absorb transient bursts and apply TCP backpressure
+            boolean added = exec.getQueue().offer(runnable, 2, TimeUnit.SECONDS);
+            if (!added) {
+              throw new RejectedExecutionException("Executor queue full after 2s wait");
+            }
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RejectedExecutionException(
+                "Interrupted while waiting for executor queue capacity", e);
+          }
+        });
     this.retryScheduler = Executors.newScheduledThreadPool(4,
         new ThreadFactoryBuilder().setNameFormat("mqtt-bridge-retry-%d").setDaemon(true).build());
   }
@@ -238,6 +262,7 @@ public class MqttToPubSubBridge {
 
           // 1. Check if any message is stuck in-flight longer than timeoutMs
           boolean hasStuckMessage = unackedMessages.values().stream()
+              .filter(record -> record != null && record.getState() == MessageState.IN_PROCESS)
               .anyMatch(record -> (now - record.getTimestamp()) >= timeoutMs);
 
           // 2. Check if abandoned messages have exhausted capacity (>= abandonedThreshold)
@@ -265,6 +290,8 @@ public class MqttToPubSubBridge {
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
           break;
+        } catch (Exception e) {
+          logger.error("Error in circuit breaker monitor", e);
         }
       }
     });
@@ -646,6 +673,11 @@ public class MqttToPubSubBridge {
               // ABORT OR SHUTDOWN IN PROGRESS, IGNORE NEW MESSAGE ARRIVALS
               return;
             }
+            logger.debug(
+                "MQTT message received: ID={}, topic={}, queueSize={}, inProcess={},"
+                    + " abandoned={}, unackedTotal={}",
+                message.getId(), topic, executor.getQueue().size(), getInProcessCount(),
+                getAbandonedCount(), getUnackedCount());
             String messageKey = null;
             try {
               messageKey = getMessageHash(topic, message);
@@ -675,6 +707,11 @@ public class MqttToPubSubBridge {
               }
 
               final String receiveTime = java.time.Instant.now().toString();
+              logger.debug(
+                  "Queueing MQTT message ID {} (queueSize={}, inProcess={},"
+                      + " abandoned={}, unackedTotal={})",
+                  message.getId(), executor.getQueue().size(), getInProcessCount(),
+                  getAbandonedCount(), getUnackedCount());
               executor.submit(() -> {
                 if (tripped) {
                   // ABORT REQUEST RECEIVED, ABANDON REQUESTS
@@ -754,14 +791,12 @@ public class MqttToPubSubBridge {
                 unackedMessages.remove(messageKey);
               }
               if (e instanceof RejectedExecutionException) {
-                logger.error("Execution rejected, queue full! Dropping MQTT connection.", e);
-                try {
-                  mqttClient.disconnectForcibly();
-                } catch (MqttException me) {
-                  logger.error("Error while forcing disconnect", me);
-                }
+                logger.warn(
+                    "Unable to queue MQTT message ID {} (queue saturated, shedding message"
+                        + " without dropping connection)",
+                    message.getId(), e);
               } else {
-                logger.error("Error submitting message to executor", e);
+                logger.error("Error submitting message ID {} to executor", message.getId(), e);
               }
             }
           }
@@ -1061,10 +1096,19 @@ public class MqttToPubSubBridge {
     logger.info("Graceful shutdown of MqttToPubSubBridge completed.");
   }
 
+  /**
+   * Shuts down the bridge executors with a default timeout of 10 seconds.
+   */
   public void shutdown() {
     shutdown(10, TimeUnit.SECONDS);
   }
 
+  /**
+   * Shuts down the bridge executors awaiting termination up to the specified timeout.
+   *
+   * @param timeout the maximum time to wait
+   * @param unit the time unit of the timeout argument
+   */
   public void shutdown(long timeout, TimeUnit unit) {
     executor.shutdown();
     retryScheduler.shutdown();

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.KeyManagerFactory;
@@ -114,6 +115,7 @@ public class MqttToPubSubBridge {
   private final ThreadPoolExecutor executor;
   private final ScheduledExecutorService retryScheduler;
   private volatile boolean tripped = false;
+  private volatile boolean stopping = false;
   private final ConcurrentHashMap<String, MessageState> unackedMessages = new ConcurrentHashMap<>();
 
   public int getUnackedCount() {
@@ -174,6 +176,14 @@ public class MqttToPubSubBridge {
 
   void setTrippedForTest(boolean tripped) {
     this.tripped = tripped;
+  }
+
+  public boolean isStopping() {
+    return stopping;
+  }
+
+  public void setStopping(boolean stopping) {
+    this.stopping = stopping;
   }
 
   private void startCircuitBreaker(IMqttClient mqttClient) {
@@ -327,6 +337,8 @@ public class MqttToPubSubBridge {
     IMqttClient mqttClient = null;
     EtcdDataProvider etcdProvider = null;
     MqttToPubSubBridge bridge = null;
+    AtomicBoolean isShuttingDown = new AtomicBoolean(false);
+    Thread shutdownHook = null;
 
     try {
       etcdProvider = createEtcdProvider(etcdTarget, etcdOptions);
@@ -361,6 +373,20 @@ public class MqttToPubSubBridge {
 
       bridge = new MqttToPubSubBridge();
 
+      final MqttToPubSubBridge finalBridge = bridge;
+      final IMqttClient finalMqttClient = mqttClient;
+      final Publisher finalPublisher = publisher;
+      final EtcdDataProvider finalEtcdProvider = etcdProvider;
+
+      Runnable shutdownTask = () -> {
+        if (isShuttingDown.compareAndSet(false, true)) {
+          gracefulShutdown(finalBridge, finalMqttClient, finalPublisher, finalEtcdProvider);
+        }
+      };
+
+      shutdownHook = new Thread(shutdownTask, "mqtt-bridge-shutdown-hook");
+      Runtime.getRuntime().addShutdownHook(shutdownHook);
+
       // Start the circuit breaker monitor
       bridge.startCircuitBreaker(mqttClient, circuitBreakerThreshold, circuitBreakerTimeoutMs);
       // Start periodic reconnect with random jitter
@@ -390,36 +416,14 @@ public class MqttToPubSubBridge {
       logger.error("An unexpected error occurred", e);
       System.exit(1);
     } finally {
-      // Shutdown
-      if (bridge != null) {
-        try {
-          bridge.shutdown();
-        } catch (Exception e) {
-          logger.warn("Error shutting down bridge executors", e);
-        }
+      if (isShuttingDown.compareAndSet(false, true)) {
+        gracefulShutdown(bridge, mqttClient, publisher, etcdProvider);
       }
-      if (etcdProvider != null) {
+      if (shutdownHook != null) {
         try {
-          etcdProvider.shutdown();
-          logger.debug("EtcdDataProvider shut down.");
-        } catch (Exception e) {
-          logger.warn("Error shutting down EtcdDataProvider", e);
-        }
-      }
-      if (mqttClient != null && mqttClient.isConnected()) {
-        try {
-          mqttClient.disconnect();
-          logger.debug("MQTT client disconnected.");
-        } catch (MqttException e) {
-          logger.warn("Error disconnecting MQTT client", e);
-        }
-      }
-      if (publisher != null) {
-        try {
-          publisher.shutdown();
-          logger.debug("Pub/Sub Publisher shut down.");
-        } catch (Exception e) {
-          logger.warn("Error shutting down Pub/Sub publisher", e);
+          Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        } catch (IllegalStateException ignored) {
+          // VM is already shutting down
         }
       }
       if (bridge != null && bridge.isTripped()) {
@@ -592,8 +596,8 @@ public class MqttToPubSubBridge {
 
           @Override
           public void messageArrived(String topic, MqttMessage message) {
-            if (tripped) {
-              // ABORT REQUEST RECEIVED, ABANDON REQUESTS
+            if (tripped || stopping) {
+              // ABORT OR SHUTDOWN IN PROGRESS, IGNORE NEW MESSAGE ARRIVALS
               return;
             }
             String messageKey = null;
@@ -950,8 +954,83 @@ public class MqttToPubSubBridge {
     }
   }
 
+  static void gracefulShutdown(MqttToPubSubBridge bridge, IMqttClient mqttClient,
+      Publisher publisher, EtcdDataProvider etcdProvider) {
+    logger.info("Initiating graceful shutdown of MqttToPubSubBridge...");
+    // 1. Signal bridge to ignore newly arriving MQTT messages
+    if (bridge != null) {
+      bridge.setStopping(true);
+    }
+
+    // 2. Shut down bridge executors and drain in-flight message processing
+    // Keep MQTT client connected while draining so PUBACKs can be returned to broker
+    if (bridge != null) {
+      try {
+        bridge.shutdown();
+        logger.debug("Bridge executors drained and shut down.");
+      } catch (Exception e) {
+        logger.warn("Error draining bridge executors", e);
+      }
+    }
+
+    // 3. Shut down Pub/Sub publisher and await pending publish futures
+    if (publisher != null) {
+      try {
+        publisher.shutdown();
+        if (!publisher.awaitTermination(10, TimeUnit.SECONDS)) {
+          logger.warn("Pub/Sub publisher did not terminate within 10 seconds");
+        }
+        logger.debug("Pub/Sub Publisher shut down.");
+      } catch (Exception e) {
+        logger.warn("Error shutting down Pub/Sub publisher", e);
+      }
+    }
+
+    // 4. Disconnect MQTT client after in-flight message ACKs have completed
+    if (mqttClient != null && mqttClient.isConnected()) {
+      try {
+        mqttClient.disconnect();
+        logger.debug("MQTT client disconnected.");
+      } catch (Exception e) {
+        logger.warn("Error disconnecting MQTT client during shutdown", e);
+      }
+    }
+
+    // 5. Shut down Etcd data provider
+    if (etcdProvider != null) {
+      try {
+        etcdProvider.shutdown();
+        logger.debug("EtcdDataProvider shut down.");
+      } catch (Exception e) {
+        logger.warn("Error shutting down EtcdDataProvider", e);
+      }
+    }
+    logger.info("Graceful shutdown of MqttToPubSubBridge completed.");
+  }
+
   public void shutdown() {
+    shutdown(10, TimeUnit.SECONDS);
+  }
+
+  public void shutdown(long timeout, TimeUnit unit) {
     executor.shutdown();
     retryScheduler.shutdown();
+    try {
+      long halfTimeout = Math.max(1, timeout / 2);
+      if (!executor.awaitTermination(halfTimeout, unit)) {
+        logger.warn("Executor did not terminate within {} {}, forcing shutdown",
+            halfTimeout, unit);
+        executor.shutdownNow();
+      }
+      if (!retryScheduler.awaitTermination(halfTimeout, unit)) {
+        logger.warn("Retry scheduler did not terminate within {} {}, forcing shutdown",
+            halfTimeout, unit);
+        retryScheduler.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      executor.shutdownNow();
+      retryScheduler.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
   }
 }

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -304,7 +304,7 @@ public class MqttToPubSubBridge {
     System.exit(status);
   }
 
-  private void startPeriodicReconnect(IMqttClient mqttClient, int baseIntervalSec) {
+  void startPeriodicReconnect(IMqttClient mqttClient, int baseIntervalSec) {
     if (baseIntervalSec <= 0) {
       return;
     }
@@ -322,7 +322,7 @@ public class MqttToPubSubBridge {
                 "Executing scheduled reconnect (interval: {}s) to rebalance shared subscription...",
                 delaySec);
             try {
-              mqttClient.disconnect();
+              mqttClient.disconnect(1000L);
             } catch (Exception e) {
               logger.warn("Error disconnecting for scheduled reconnect", e);
             }

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -100,14 +100,14 @@ public class MqttToPubSubBridge {
       .maximumSize(10000)
       .build();
 
-  private static final Cache<String, Boolean> ackedMessageIds = CacheBuilder.newBuilder()
-      .expireAfterWrite(15, TimeUnit.MINUTES)
-      .maximumSize(10000)
-      .build();
+  public enum UnackedState {
+    IN_PROCESS,
+    ABANDONED
+  }
 
   private final ThreadPoolExecutor executor;
   private volatile boolean tripped = false;
-  private final ConcurrentMap<Integer, Long> unackedMessages = new ConcurrentHashMap<>();
+  private final ConcurrentMap<Integer, UnackedState> unackedMessages = new ConcurrentHashMap<>();
   private final AtomicInteger dupCount = new AtomicInteger(0);
   private final Random random = new Random();
 
@@ -121,7 +121,6 @@ public class MqttToPubSubBridge {
 
   static void clearCacheForTest() {
     numIdCache.invalidateAll();
-    ackedMessageIds.invalidateAll();
   }
 
   /**
@@ -191,7 +190,16 @@ public class MqttToPubSubBridge {
           synchronized (mqttClient) {
             if (mqttClient.isConnected() && !tripped) {
               logger.info("Executing scheduled reconnect (interval: {}s) to rebalance shared subscription...", delaySec);
-              mqttClient.reconnect();
+              try {
+                mqttClient.disconnect();
+              } catch (Exception e) {
+                logger.warn("Error disconnecting for scheduled reconnect", e);
+              }
+              try {
+                mqttClient.reconnect();
+              } catch (Exception e) {
+                logger.warn("Error reconnecting during scheduled reconnect", e);
+              }
             }
           }
         } catch (InterruptedException e) {
@@ -506,23 +514,14 @@ public class MqttToPubSubBridge {
                 int currentDups = dupCount.incrementAndGet();
                 logger.info("Received DUP MQTT message (DUP=true, ID {}). Total DUP messages tracked: {}",
                     message.getId(), currentDups);
-                String dupKey = message.getId() + ":" + topic;
-                if (ackedMessageIds.getIfPresent(dupKey) != null) {
-                  logger.warn("DUP message ID {} on topic {} was already published to Pub/Sub. Re-ACKing without duplicate publish.",
-                      message.getId(), topic);
-                  try {
-                    mqttClient.messageArrivedComplete(message.getId(), message.getQos());
-                  } catch (MqttException e) {
-                    logger.error("Failed to ACK already-processed DUP message", e);
-                  }
-                  return;
-                }
-                if (unackedMessages.containsKey(message.getId())) {
-                  logger.warn("DUP message ID {} is already currently inflight/unacked. Ignoring duplicate processing.",
-                      message.getId());
-                  return;
-                }
               }
+
+              if (unackedMessages.get(message.getId()) == UnackedState.IN_PROCESS) {
+                logger.warn("MQTT message ID {} is already IN_PROCESS. Skipping queue to avoid duplicate processing.",
+                    message.getId());
+                return;
+              }
+              unackedMessages.put(message.getId(), UnackedState.IN_PROCESS);
 
               final String receiveTime = java.time.Instant.now().toString();
               executor.submit(() -> {
@@ -582,8 +581,7 @@ public class MqttToPubSubBridge {
                   PubsubMessage pubsubMessage =
                       pubsubMessageBuilder.putAllAttributes(attributes).build();
 
-                  // Track unacked message ID in unackedMessages map and publish with 5x retry + exponential backoff
-                  unackedMessages.put(message.getId(), System.currentTimeMillis());
+                  // Publish with 5x retry + exponential backoff
                   publishWithRetry(publisher, pubsubMessage, message, topic, mqttClient, 1);
 
                 } catch (RuntimeException e) {
@@ -620,8 +618,6 @@ public class MqttToPubSubBridge {
       public void onSuccess(String msgId) {
         logger.debug("Published to Pub/Sub with message ID: {}", msgId);
         unackedMessages.remove(mqttMessage.getId());
-        String dupKey = mqttMessage.getId() + ":" + topic;
-        ackedMessageIds.put(dupKey, Boolean.TRUE);
         try {
           mqttClient.messageArrivedComplete(mqttMessage.getId(), mqttMessage.getQos());
         } catch (MqttException e) {
@@ -645,8 +641,9 @@ public class MqttToPubSubBridge {
             }
           });
         } else {
-          logger.error("Failed to publish to Pub/Sub after 5 attempts. Message left unacked.", t);
-          // Note: unackedMessages retains the message ID so circuit breaker can trip on prolonged outage
+          logger.error("Failed to publish to Pub/Sub after 5 attempts. Marking message ID {} as ABANDONED (unacked).",
+              mqttMessage.getId(), t);
+          unackedMessages.put(mqttMessage.getId(), UnackedState.ABANDONED);
         }
       }
     }, MoreExecutors.directExecutor());

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -107,6 +107,35 @@ public class MqttToPubSubBridge {
     ABANDONED
   }
 
+  /**
+   * Represents a recorded message entry tracking its state and insertion timestamp.
+   */
+  public static class MessageRecord {
+    private final long timestamp;
+    private volatile MessageState state;
+
+    public MessageRecord(MessageState state) {
+      this(state, System.currentTimeMillis());
+    }
+
+    public MessageRecord(MessageState state, long timestamp) {
+      this.state = state;
+      this.timestamp = timestamp;
+    }
+
+    public long getTimestamp() {
+      return timestamp;
+    }
+
+    public MessageState getState() {
+      return state;
+    }
+
+    public void setState(MessageState state) {
+      this.state = state;
+    }
+  }
+
   private static final Cache<String, String> numIdCache = CacheBuilder.newBuilder()
       .expireAfterWrite(1, TimeUnit.MINUTES)
       .maximumSize(10000)
@@ -116,7 +145,8 @@ public class MqttToPubSubBridge {
   private final ScheduledExecutorService retryScheduler;
   private volatile boolean tripped = false;
   private volatile boolean stopping = false;
-  private final ConcurrentHashMap<String, MessageState> unackedMessages = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, MessageRecord> unackedMessages =
+      new ConcurrentHashMap<>();
 
   public int getUnackedCount() {
     return unackedMessages.size();
@@ -124,16 +154,25 @@ public class MqttToPubSubBridge {
 
   public int getInProcessCount() {
     return (int) unackedMessages.values().stream()
-        .filter(s -> s == MessageState.IN_PROCESS).count();
+        .filter(r -> r.getState() == MessageState.IN_PROCESS).count();
   }
 
   public int getAbandonedCount() {
     return (int) unackedMessages.values().stream()
-        .filter(s -> s == MessageState.ABANDONED).count();
+        .filter(r -> r.getState() == MessageState.ABANDONED).count();
   }
 
   public MessageState getMessageState(String messageKey) {
+    MessageRecord record = unackedMessages.get(messageKey);
+    return record != null ? record.getState() : null;
+  }
+
+  public MessageRecord getMessageRecord(String messageKey) {
     return unackedMessages.get(messageKey);
+  }
+
+  void putMessageRecordForTest(String messageKey, MessageRecord record) {
+    unackedMessages.put(messageKey, record);
   }
 
   static String getMessageHash(String topic, MqttMessage message) {
@@ -190,31 +229,38 @@ public class MqttToPubSubBridge {
     startCircuitBreaker(mqttClient, DEFAULT_UNACKED_THRESHOLD, DEFAULT_CIRCUIT_BREAKER_TIMEOUT_MS);
   }
 
-  void startCircuitBreaker(IMqttClient mqttClient, int threshold, long timeoutMs) {
+  void startCircuitBreaker(IMqttClient mqttClient, int abandonedThreshold, long timeoutMs) {
     Thread monitor = new Thread(() -> {
-      long fullStartTime = 0;
-      while (!tripped) {
+      while (!tripped && !stopping) {
         try {
           Thread.sleep(1000);
-          // Check if total unacked messages (IN_PROCESS + ABANDONED) exceed threshold
-          if (unackedMessages.size() >= threshold) {
-            if (fullStartTime == 0) {
-              fullStartTime = System.currentTimeMillis();
-            } else if (System.currentTimeMillis() - fullStartTime >= timeoutMs) {
-              tripped = true;
+          long now = System.currentTimeMillis();
+
+          // 1. Check if any message is stuck in-flight longer than timeoutMs
+          boolean hasStuckMessage = unackedMessages.values().stream()
+              .anyMatch(record -> (now - record.getTimestamp()) >= timeoutMs);
+
+          // 2. Check if abandoned messages have exhausted capacity (>= abandonedThreshold)
+          boolean abandonedExceeded = getAbandonedCount() >= abandonedThreshold;
+
+          if (hasStuckMessage || abandonedExceeded) {
+            tripped = true;
+            if (hasStuckMessage) {
               logger.error(
-                  "Unacked message threshold ({} messages) exceeded for {}ms! "
-                      + "Tripping circuit breaker.",
-                  threshold, timeoutMs);
-              try {
-                mqttClient.disconnectForcibly();
-              } catch (Exception e) {
-                logger.error("Error disconnecting during circuit breaker trip", e);
-              }
-              exit(1);
+                  "Message stuck in unacked queue for >= {}ms! Tripping circuit breaker.",
+                  timeoutMs);
             }
-          } else {
-            fullStartTime = 0; // reset
+            if (abandonedExceeded) {
+              logger.error(
+                  "Abandoned message threshold ({} messages) reached! Tripping circuit breaker.",
+                  abandonedThreshold);
+            }
+            try {
+              mqttClient.disconnectForcibly();
+            } catch (Exception e) {
+              logger.error("Error disconnecting during circuit breaker trip", e);
+            }
+            exit(1);
           }
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
@@ -465,9 +511,9 @@ public class MqttToPubSubBridge {
     options.addOption(null, "clean_start", false,
         "Enable clean start for MQTT connection (alias for mqtt_clean_start).");
     options.addOption(null, "circuit_breaker_unacked_threshold", true,
-        "Unacked message count threshold for circuit breaker (default 100).");
+        "Abandoned message count threshold for circuit breaker (default 100).");
     options.addOption(null, "circuit_breaker_timeout_sec", true,
-        "Timeout in seconds for circuit breaker threshold (default 300).");
+        "Max in-flight message age in seconds before circuit breaker trips (default 300).");
     options.addOption("h", "help", false, "Print usage info.");
 
     CommandLineParser parser = new DefaultParser();
@@ -608,15 +654,16 @@ public class MqttToPubSubBridge {
               final java.util.concurrent.atomic.AtomicBoolean shouldProcess =
                   new java.util.concurrent.atomic.AtomicBoolean(false);
 
-              unackedMessages.compute(finalMessageKey, (key, existingState) -> {
-                if (existingState == MessageState.IN_PROCESS) {
+              unackedMessages.compute(finalMessageKey, (key, existingRecord) -> {
+                if (existingRecord != null
+                    && existingRecord.getState() == MessageState.IN_PROCESS) {
                   // Message is currently in-flight, skip queue
-                  return MessageState.IN_PROCESS;
+                  return existingRecord;
                 }
-                // New message (existingState == null) OR previously ABANDONED
+                // New message (existingRecord == null) OR previously ABANDONED
                 // Transition to IN_PROCESS and process
                 shouldProcess.set(true);
-                return MessageState.IN_PROCESS;
+                return new MessageRecord(MessageState.IN_PROCESS);
               });
 
               if (!shouldProcess.get()) {
@@ -790,7 +837,13 @@ public class MqttToPubSubBridge {
           "Failed to publish to Pub/Sub after 5 attempts."
               + " Leaving message ID {} unacked (marked as ABANDONED).",
           mqttMessage.getId(), t);
-      unackedMessages.put(messageKey, MessageState.ABANDONED);
+      unackedMessages.compute(messageKey, (key, existingRecord) -> {
+        if (existingRecord != null) {
+          existingRecord.setState(MessageState.ABANDONED);
+          return existingRecord;
+        }
+        return new MessageRecord(MessageState.ABANDONED);
+      });
     }
   }
 

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -35,13 +35,12 @@ import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -116,18 +115,19 @@ public class MqttToPubSubBridge {
   private final ScheduledExecutorService retryScheduler;
   private volatile boolean tripped = false;
   private final ConcurrentHashMap<String, MessageState> unackedMessages = new ConcurrentHashMap<>();
-  private final Random random = new Random();
 
   public int getUnackedCount() {
     return unackedMessages.size();
   }
 
   public int getInProcessCount() {
-    return (int) unackedMessages.values().stream().filter(s -> s == MessageState.IN_PROCESS).count();
+    return (int) unackedMessages.values().stream()
+        .filter(s -> s == MessageState.IN_PROCESS).count();
   }
 
   public int getAbandonedCount() {
-    return (int) unackedMessages.values().stream().filter(s -> s == MessageState.ABANDONED).count();
+    return (int) unackedMessages.values().stream()
+        .filter(s -> s == MessageState.ABANDONED).count();
   }
 
   public MessageState getMessageState(String messageKey) {
@@ -137,7 +137,8 @@ public class MqttToPubSubBridge {
   static String getMessageHash(String topic, MqttMessage message) {
     byte[] payload = message.getPayload() != null ? message.getPayload() : new byte[0];
     String payloadHash = Hashing.murmur3_128().hashBytes(payload).toString();
-    return (topic != null && !topic.isEmpty() ? topic + ":" : "") + message.getId() + ":" + payloadHash;
+    String prefix = topic != null && !topic.isEmpty() ? topic + ":" : "";
+    return prefix + message.getId() + ":" + payloadHash;
   }
 
   static String getMessageHash(MqttMessage message) {
@@ -192,10 +193,11 @@ public class MqttToPubSubBridge {
             } else if (System.currentTimeMillis() - fullStartTime >= timeoutMs) {
               tripped = true;
               logger.error(
-                  "Unacked message threshold ({} messages) exceeded for {}ms! Tripping circuit breaker.",
+                  "Unacked message threshold ({} messages) exceeded for {}ms! "
+                      + "Tripping circuit breaker.",
                   threshold, timeoutMs);
               try {
-                mqttClient.disconnect();
+                mqttClient.disconnectForcibly();
               } catch (Exception e) {
                 logger.error("Error disconnecting during circuit breaker trip", e);
               }
@@ -229,7 +231,8 @@ public class MqttToPubSubBridge {
           // Jitter: +/- 50% random delay around baseIntervalSec
           int jitterSec = (int) (baseIntervalSec * 0.5);
           int delaySec = baseIntervalSec
-              + (jitterSec > 0 ? (random.nextInt(jitterSec * 2 + 1) - jitterSec) : 0);
+              + (jitterSec > 0
+              ? (ThreadLocalRandom.current().nextInt(jitterSec * 2 + 1) - jitterSec) : 0);
           Thread.sleep(Math.max(1, delaySec) * 1000L);
           if (mqttClient.isConnected() && !tripped) {
             logger.info(
@@ -243,7 +246,9 @@ public class MqttToPubSubBridge {
             try {
               mqttClient.reconnect();
             } catch (Exception e) {
-              logger.error("FATAL: Error reconnecting during scheduled reconnect. Exiting for K8s restart.", e);
+              logger.error(
+                  "FATAL: Error reconnecting during scheduled reconnect. Exiting for K8s restart.",
+                  e);
               exit(1);
             }
           }
@@ -290,6 +295,13 @@ public class MqttToPubSubBridge {
     boolean mqttTls = commandLine.hasOption("mqtt_tls");
     int reconnectIntervalSec = Integer.parseInt(
         commandLine.getOptionValue("mqtt_reconnect_interval_sec", "900"));
+    int circuitBreakerThreshold = Integer.parseInt(
+        commandLine.getOptionValue("circuit_breaker_unacked_threshold",
+            String.valueOf(DEFAULT_UNACKED_THRESHOLD)));
+    long circuitBreakerTimeoutMs = Long.parseLong(
+        commandLine.getOptionValue("circuit_breaker_timeout_sec", "300")) * 1000L;
+    boolean cleanStart = commandLine.hasOption("mqtt_clean_start")
+        || commandLine.hasOption("clean_start");
     String mqttCaPath = commandLine.getOptionValue("mqtt_ca_path");
     String mqttUsername = commandLine.getOptionValue("mqtt_username");
     String mqttPassword = commandLine.getOptionValue("mqtt_password");
@@ -325,7 +337,7 @@ public class MqttToPubSubBridge {
           new MqttClient(
               mqttBrokerUrl, mqttClientId, new MemoryPersistence());
       MqttConnectionOptions connOpts = new MqttConnectionOptions();
-      connOpts.setCleanStart(false);
+      connOpts.setCleanStart(cleanStart);
       connOpts.setSessionExpiryInterval(sessionExpiryInterval);
       connOpts.setKeepAliveInterval(keepAliveInterval);
       connOpts.setAutomaticReconnect(true);
@@ -350,7 +362,7 @@ public class MqttToPubSubBridge {
       bridge = new MqttToPubSubBridge();
 
       // Start the circuit breaker monitor
-      bridge.startCircuitBreaker(mqttClient);
+      bridge.startCircuitBreaker(mqttClient, circuitBreakerThreshold, circuitBreakerTimeoutMs);
       // Start periodic reconnect with random jitter
       bridge.startPeriodicReconnect(mqttClient, reconnectIntervalSec);
 
@@ -444,6 +456,14 @@ public class MqttToPubSubBridge {
     options.addOption(null, "shared_subscription", true, "Shared subscription name.");
     options.addOption(null, "mqtt_reconnect_interval_sec", true,
         "Periodic reconnect interval in seconds (default 900, 0 to disable).");
+    options.addOption(null, "mqtt_clean_start", false,
+        "Enable clean start for MQTT connection (default false for persistent session).");
+    options.addOption(null, "clean_start", false,
+        "Enable clean start for MQTT connection (alias for mqtt_clean_start).");
+    options.addOption(null, "circuit_breaker_unacked_threshold", true,
+        "Unacked message count threshold for circuit breaker (default 100).");
+    options.addOption(null, "circuit_breaker_timeout_sec", true,
+        "Timeout in seconds for circuit breaker threshold (default 300).");
     options.addOption("h", "help", false, "Print usage info.");
 
     CommandLineParser parser = new DefaultParser();
@@ -544,7 +564,7 @@ public class MqttToPubSubBridge {
               logger.debug("MQTT automatically reconnected to broker: {}", serverUri);
               executor.submit(() -> {
                 if (tripped) {
-                  // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+                  // ABORT REQUEST RECEIVED, ABANDON REQUESTS
                   return;
                 }
                 try {
@@ -667,7 +687,8 @@ public class MqttToPubSubBridge {
                       pubsubMessageBuilder.putAllAttributes(attributes).build();
 
                   // Publish with 5x retry + exponential backoff
-                  publishWithRetry(publisher, pubsubMessage, message, finalMessageKey, topic, mqttClient, 1);
+                  publishWithRetry(publisher, pubsubMessage, message, finalMessageKey,
+                      topic, mqttClient, 1);
                   publishInitiated = true;
                 } catch (Exception e) {
                   logger.warn("Error processing MQTT message", e);
@@ -707,7 +728,8 @@ public class MqttToPubSubBridge {
   }
 
   private void publishWithRetry(Publisher publisher, PubsubMessage pubsubMessage,
-      MqttMessage mqttMessage, String messageKey, String topic, IMqttClient mqttClient, int attempt) {
+      MqttMessage mqttMessage, String messageKey, String topic, IMqttClient mqttClient,
+      int attempt) {
     if (tripped) {
       // ABORT REQUEST RECEIVED, ABANDON REQUESTS
       return;
@@ -743,10 +765,12 @@ public class MqttToPubSubBridge {
   }
 
   private void handlePublishFailure(Publisher publisher, PubsubMessage pubsubMessage,
-      MqttMessage mqttMessage, String messageKey, String topic, IMqttClient mqttClient, int attempt, Throwable t) {
+      MqttMessage mqttMessage, String messageKey, String topic, IMqttClient mqttClient,
+      int attempt, Throwable t) {
     if (attempt < 5 && !tripped) {
       long baseMs = (1L << (attempt - 1)) * 800L;
-      int backoffMs = (int) baseMs + random.nextInt((int) (baseMs * 0.5));
+      int backoffMs = (int) baseMs
+          + ThreadLocalRandom.current().nextInt((int) (baseMs * 0.5));
       logger.warn("Error publishing to Pub/Sub (attempt {}/5), retrying in {}ms...",
           attempt, backoffMs, t);
       retryScheduler.schedule(() -> {
@@ -754,7 +778,8 @@ public class MqttToPubSubBridge {
           // ABORT REQUEST RECEIVED, ABANDON REQUESTS
           return;
         }
-        publishWithRetry(publisher, pubsubMessage, mqttMessage, messageKey, topic, mqttClient, attempt + 1);
+        publishWithRetry(publisher, pubsubMessage, mqttMessage, messageKey,
+            topic, mqttClient, attempt + 1);
       }, backoffMs, TimeUnit.MILLISECONDS);
     } else {
       logger.error(

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -34,10 +34,14 @@ import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.KeyManagerFactory;
@@ -96,11 +100,28 @@ public class MqttToPubSubBridge {
       .maximumSize(10000)
       .build();
 
+  private static final Cache<String, Boolean> ackedMessageIds = CacheBuilder.newBuilder()
+      .expireAfterWrite(15, TimeUnit.MINUTES)
+      .maximumSize(10000)
+      .build();
+
   private final ThreadPoolExecutor executor;
   private volatile boolean tripped = false;
+  private final ConcurrentMap<Integer, Long> unackedMessages = new ConcurrentHashMap<>();
+  private final AtomicInteger dupCount = new AtomicInteger(0);
+  private final Random random = new Random();
+
+  public int getDupCount() {
+    return dupCount.get();
+  }
+
+  public int getUnackedCount() {
+    return unackedMessages.size();
+  }
 
   static void clearCacheForTest() {
     numIdCache.invalidateAll();
+    ackedMessageIds.invalidateAll();
   }
 
   /**
@@ -130,13 +151,13 @@ public class MqttToPubSubBridge {
       while (!tripped) {
         try {
           Thread.sleep(1000);
-          // Check if we've received the maximum number of inflight messages (100)
-          if (executor.getActiveCount() + executor.getQueue().size() >= 100) {
+          // Check if unacked inflight messages exceed threshold (50 out of RECEIVE_MAXIMUM = 100)
+          if (unackedMessages.size() >= 50) {
             if (fullStartTime == 0) {
               fullStartTime = System.currentTimeMillis();
-            } else if (System.currentTimeMillis() - fullStartTime >= 60000) {
+            } else if (System.currentTimeMillis() - fullStartTime >= 300000) {
               tripped = true;
-              logger.error("Queue saturated for 60 seconds! Tripping circuit breaker.");
+              logger.error("Unacked message threshold exceeded for 300 seconds! Tripping circuit breaker.");
               try {
                 mqttClient.disconnect();
               } catch (Exception e) {
@@ -154,6 +175,36 @@ public class MqttToPubSubBridge {
     });
     monitor.setDaemon(true);
     monitor.start();
+  }
+
+  private void startPeriodicReconnect(IMqttClient mqttClient, int baseIntervalSec) {
+    if (baseIntervalSec <= 0) {
+      return;
+    }
+    Thread reconnectThread = new Thread(() -> {
+      while (!tripped) {
+        try {
+          // Jitter: +/- 50% random delay around baseIntervalSec
+          int jitterSec = (int) (baseIntervalSec * 0.5);
+          int delaySec = baseIntervalSec + (jitterSec > 0 ? (random.nextInt(jitterSec * 2 + 1) - jitterSec) : 0);
+          Thread.sleep(Math.max(1, delaySec) * 1000L);
+          synchronized (mqttClient) {
+            if (mqttClient.isConnected() && !tripped) {
+              logger.info("Executing scheduled reconnect (interval: {}s) to rebalance shared subscription...", delaySec);
+              mqttClient.reconnect();
+            }
+          }
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        } catch (Exception e) {
+          logger.warn("Error during scheduled reconnect", e);
+        }
+      }
+    });
+    reconnectThread.setDaemon(true);
+    reconnectThread.setName("mqtt-reconnect-timer");
+    reconnectThread.start();
   }
 
   /**
@@ -184,6 +235,8 @@ public class MqttToPubSubBridge {
     String mqttKeepAliveInterval = commandLine.getOptionValue("mqtt_keep_alive_interval", "15");
     int keepAliveInterval = Integer.parseInt(mqttKeepAliveInterval);
     boolean mqttTls = commandLine.hasOption("mqtt_tls");
+    int reconnectIntervalSec = Integer.parseInt(
+        commandLine.getOptionValue("mqtt_reconnect_interval_sec", "900"));
     String mqttCaPath = commandLine.getOptionValue("mqtt_ca_path");
     String mqttUsername = commandLine.getOptionValue("mqtt_username");
     String mqttPassword = commandLine.getOptionValue("mqtt_password");
@@ -244,6 +297,8 @@ public class MqttToPubSubBridge {
 
       // Start the circuit breaker monitor
       bridge.startCircuitBreaker(mqttClient);
+      // Start periodic reconnect with random jitter
+      bridge.startPeriodicReconnect(mqttClient, reconnectIntervalSec);
 
       // Set up MQTT Message Callback
       bridge.setupBridge(mqttClient, publisher, mqttSubscriptionTopic,
@@ -320,6 +375,8 @@ public class MqttToPubSubBridge {
         "Path to client private key for etcd TLS.");
     options.addOption(null, "source_attribute", true, "Value for the source attribute.");
     options.addOption(null, "shared_subscription", true, "Shared subscription name.");
+    options.addOption(null, "mqtt_reconnect_interval_sec", true,
+        "Periodic reconnect interval in seconds (default 900, 0 to disable).");
     options.addOption("h", "help", false, "Print usage info.");
 
     CommandLineParser parser = new DefaultParser();
@@ -445,6 +502,28 @@ public class MqttToPubSubBridge {
           @Override
           public void messageArrived(String topic, MqttMessage message) {
             try {
+              if (message.isDuplicate()) {
+                int currentDups = dupCount.incrementAndGet();
+                logger.info("Received DUP MQTT message (DUP=true, ID {}). Total DUP messages tracked: {}",
+                    message.getId(), currentDups);
+                String dupKey = message.getId() + ":" + topic;
+                if (ackedMessageIds.getIfPresent(dupKey) != null) {
+                  logger.warn("DUP message ID {} on topic {} was already published to Pub/Sub. Re-ACKing without duplicate publish.",
+                      message.getId(), topic);
+                  try {
+                    mqttClient.messageArrivedComplete(message.getId(), message.getQos());
+                  } catch (MqttException e) {
+                    logger.error("Failed to ACK already-processed DUP message", e);
+                  }
+                  return;
+                }
+                if (unackedMessages.containsKey(message.getId())) {
+                  logger.warn("DUP message ID {} is already currently inflight/unacked. Ignoring duplicate processing.",
+                      message.getId());
+                  return;
+                }
+              }
+
               final String receiveTime = java.time.Instant.now().toString();
               executor.submit(() -> {
                 try {
@@ -503,25 +582,9 @@ public class MqttToPubSubBridge {
                   PubsubMessage pubsubMessage =
                       pubsubMessageBuilder.putAllAttributes(attributes).build();
 
-                  // Publish to Pub/Sub and acknowledge asynchronously
-                  ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
-                  ApiFutures.addCallback(messageIdFuture, new ApiFutureCallback<String>() {
-                    @Override
-                    public void onSuccess(String msgId) {
-                      logger.debug("Published to Pub/Sub with message ID: {}", msgId);
-                      try {
-                        mqttClient.messageArrivedComplete(message.getId(), message.getQos());
-                      } catch (MqttException e) {
-                        logger.error("Failed to ACK MQTT message, it will be redelivered", e);
-                      }
-                    }
-
-                    @Override
-                    public void onFailure(Throwable t) {
-                      logger.warn(
-                          "Error publishing to Pub/Sub, dropping ACK so broker can redeliver", t);
-                    }
-                  }, MoreExecutors.directExecutor());
+                  // Track unacked message ID in unackedMessages map and publish with 5x retry + exponential backoff
+                  unackedMessages.put(message.getId(), System.currentTimeMillis());
+                  publishWithRetry(publisher, pubsubMessage, message, topic, mqttClient, 1);
 
                 } catch (RuntimeException e) {
                   logger.warn("Error processing MQTT message", e);
@@ -547,6 +610,46 @@ public class MqttToPubSubBridge {
     logger.debug("Subscribing to MQTT topic: {}", actualSubscriptionTopic);
     mqttClient.subscribe(actualSubscriptionTopic, 1);
     logger.debug("Subscribed. Waiting for messages...");
+  }
+
+  private void publishWithRetry(Publisher publisher, PubsubMessage pubsubMessage,
+      MqttMessage mqttMessage, String topic, IMqttClient mqttClient, int attempt) {
+    ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
+    ApiFutures.addCallback(messageIdFuture, new ApiFutureCallback<String>() {
+      @Override
+      public void onSuccess(String msgId) {
+        logger.debug("Published to Pub/Sub with message ID: {}", msgId);
+        unackedMessages.remove(mqttMessage.getId());
+        String dupKey = mqttMessage.getId() + ":" + topic;
+        ackedMessageIds.put(dupKey, Boolean.TRUE);
+        try {
+          mqttClient.messageArrivedComplete(mqttMessage.getId(), mqttMessage.getQos());
+        } catch (MqttException e) {
+          logger.error("Failed to ACK MQTT message, it will be redelivered", e);
+        }
+      }
+
+      @Override
+      public void onFailure(Throwable t) {
+        if (attempt < 5 && !tripped) {
+          long baseMs = (1L << (attempt - 1)) * 800L;
+          int backoffMs = (int) baseMs + random.nextInt((int) (baseMs * 0.5));
+          logger.warn("Error publishing to Pub/Sub (attempt {}/5), retrying in {}ms...",
+              attempt, backoffMs, t);
+          executor.submit(() -> {
+            try {
+              Thread.sleep(backoffMs);
+              publishWithRetry(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt + 1);
+            } catch (InterruptedException ie) {
+              Thread.currentThread().interrupt();
+            }
+          });
+        } else {
+          logger.error("Failed to publish to Pub/Sub after 5 attempts. Message left unacked.", t);
+          // Note: unackedMessages retains the message ID so circuit breaker can trip on prolonged outage
+        }
+      }
+    }, MoreExecutors.directExecutor());
   }
 
   private static SSLSocketFactory getSocketFactory(

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -11,6 +11,7 @@ import com.google.cloud.pubsub.v1.Publisher;
 import com.google.common.base.Splitter;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
@@ -35,15 +36,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.KeyManagerFactory;
@@ -102,27 +102,20 @@ public class MqttToPubSubBridge {
       .maximumSize(10000)
       .build();
 
-  /**
-   * Represents the state of an unacknowledged MQTT message.
-   */
-  public enum UnackedState {
-    IN_PROCESS,
-    ABANDONED
-  }
-
   private final ThreadPoolExecutor executor;
   private final ScheduledExecutorService retryScheduler;
   private volatile boolean tripped = false;
-  private final ConcurrentMap<Integer, UnackedState> unackedMessages = new ConcurrentHashMap<>();
-  private final AtomicInteger dupCount = new AtomicInteger(0);
+  private final Set<String> unackedMessages = ConcurrentHashMap.newKeySet();
   private final Random random = new Random();
-
-  public int getDupCount() {
-    return dupCount.get();
-  }
 
   public int getUnackedCount() {
     return unackedMessages.size();
+  }
+
+  static String getMessageHash(MqttMessage message) {
+    byte[] payload = message.getPayload() != null ? message.getPayload() : new byte[0];
+    String payloadHash = Hashing.murmur3_128().hashBytes(payload).toString();
+    return message.getId() + ":" + payloadHash;
   }
 
   static void clearCacheForTest() {
@@ -150,6 +143,10 @@ public class MqttToPubSubBridge {
    */
   public boolean isTripped() {
     return tripped;
+  }
+
+  void setTrippedForTest(boolean tripped) {
+    this.tripped = tripped;
   }
 
   private void startCircuitBreaker(IMqttClient mqttClient) {
@@ -494,6 +491,10 @@ public class MqttToPubSubBridge {
             if (reconnect) {
               logger.debug("MQTT automatically reconnected to broker: {}", serverUri);
               executor.submit(() -> {
+                if (tripped) {
+                  // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+                  return;
+                }
                 try {
                   mqttClient.subscribe(actualSubscriptionTopic, 1);
                   logger.debug("Successfully re-subscribed to topic: {}", actualSubscriptionTopic);
@@ -519,32 +520,28 @@ public class MqttToPubSubBridge {
 
           @Override
           public void messageArrived(String topic, MqttMessage message) {
+            if (tripped) {
+              // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+              return;
+            }
+            String messageKey = null;
             try {
-              if (message.isDuplicate()) {
-                int currentDups = dupCount.incrementAndGet();
-                logger.info(
-                    "Received DUP MQTT message (DUP=true, ID {}). Total DUP messages tracked: {}",
-                    message.getId(), currentDups);
+              messageKey = getMessageHash(message);
+              if (!unackedMessages.add(messageKey)) {
+                logger.warn(
+                    "MQTT message ID {} (hash: {}) is already in process."
+                            + " Skipping queue to avoid duplicate processing.",
+                    message.getId(), messageKey);
+                return;
               }
 
-              if (unackedMessages.get(message.getId()) == UnackedState.IN_PROCESS) {
-                if (message.isDuplicate()) {
-                  logger.warn(
-                      "MQTT message ID {} is already IN_PROCESS."
-                          + " Skipping queue to avoid duplicate processing.",
-                      message.getId());
-                  return;
-                } else {
-                  logger.warn(
-                      "MQTT message ID {} is already IN_PROCESS but DUP flag is false"
-                          + " (ID wrap-around). Processing new message.",
-                      message.getId());
-                }
-              }
-              unackedMessages.put(message.getId(), UnackedState.IN_PROCESS);
-
+              final String finalMessageKey = messageKey;
               final String receiveTime = java.time.Instant.now().toString();
               executor.submit(() -> {
+                if (tripped) {
+                  // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+                  return;
+                }
                 boolean publishInitiated = false;
                 try {
                   byte[] payload = message.getPayload();
@@ -609,12 +606,14 @@ public class MqttToPubSubBridge {
                   logger.warn("Error processing MQTT message", e);
                 } finally {
                   if (!publishInitiated) {
-                    unackedMessages.remove(message.getId());
+                    unackedMessages.remove(finalMessageKey);
                   }
                 }
               });
             } catch (Exception e) {
-              unackedMessages.remove(message.getId());
+              if (messageKey != null) {
+                unackedMessages.remove(messageKey);
+              }
               if (e instanceof RejectedExecutionException) {
                 logger.error("Execution rejected, queue full! Dropping MQTT connection.", e);
                 try {
@@ -642,14 +641,21 @@ public class MqttToPubSubBridge {
 
   private void publishWithRetry(Publisher publisher, PubsubMessage pubsubMessage,
       MqttMessage mqttMessage, String topic, IMqttClient mqttClient, int attempt) {
+    if (tripped) {
+      // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+      return;
+    }
     try {
       ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
       ApiFutures.addCallback(messageIdFuture, new ApiFutureCallback<String>() {
         @Override
         public void onSuccess(String msgId) {
+          if (tripped) {
+            // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+            return;
+          }
           logger.debug("Published to Pub/Sub with message ID: {}", msgId);
-          unackedMessages.remove(mqttMessage.getId());
-          unackedMessages.entrySet().removeIf(entry -> entry.getValue() == UnackedState.ABANDONED);
+          unackedMessages.remove(getMessageHash(mqttMessage));
           try {
             mqttClient.messageArrivedComplete(mqttMessage.getId(), mqttMessage.getQos());
           } catch (MqttException e) {
@@ -677,14 +683,18 @@ public class MqttToPubSubBridge {
       logger.warn("Error publishing to Pub/Sub (attempt {}/5), retrying in {}ms...",
           attempt, backoffMs, t);
       retryScheduler.schedule(() -> {
+        if (tripped) {
+          // ABORT REQUEST RECIEVED, ABANDON REQUESTS
+          return;
+        }
         publishWithRetry(publisher, pubsubMessage, mqttMessage, topic, mqttClient, attempt + 1);
       }, backoffMs, TimeUnit.MILLISECONDS);
     } else {
       logger.error(
           "Failed to publish to Pub/Sub after 5 attempts."
-              + " Marking message ID {} as ABANDONED (unacked).",
-          mqttMessage.getId(), t);
-      unackedMessages.put(mqttMessage.getId(), UnackedState.ABANDONED);
+              + " Leaving message ID {} unacked.",
+              mqttMessage.getId(), t);
+      unackedMessages.remove(getMessageHash(mqttMessage));
     }
   }
 

--- a/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridge.java
@@ -678,45 +678,37 @@ public class MqttToPubSubBridge {
                     + " abandoned={}, unackedTotal={}",
                 message.getId(), topic, executor.getQueue().size(), getInProcessCount(),
                 getAbandonedCount(), getUnackedCount());
-            String messageKey = null;
+            final String receiveTime = java.time.Instant.now().toString();
             try {
-              messageKey = getMessageHash(topic, message);
-              final String finalMessageKey = messageKey;
-
-              final java.util.concurrent.atomic.AtomicBoolean shouldProcess =
-                  new java.util.concurrent.atomic.AtomicBoolean(false);
-
-              unackedMessages.compute(finalMessageKey, (key, existingRecord) -> {
-                if (existingRecord != null
-                    && existingRecord.getState() == MessageState.IN_PROCESS) {
-                  // Message is currently in-flight, skip queue
-                  return existingRecord;
-                }
-                // New message (existingRecord == null) OR previously ABANDONED
-                // Transition to IN_PROCESS and process
-                shouldProcess.set(true);
-                return new MessageRecord(MessageState.IN_PROCESS);
-              });
-
-              if (!shouldProcess.get()) {
-                logger.warn(
-                    "MQTT message ID {} (key: {}) is already in process."
-                            + " Skipping queue to avoid duplicate processing.",
-                    message.getId(), finalMessageKey);
-                return;
-              }
-
-              final String receiveTime = java.time.Instant.now().toString();
-              logger.debug(
-                  "Queueing MQTT message ID {} (queueSize={}, inProcess={},"
-                      + " abandoned={}, unackedTotal={})",
-                  message.getId(), executor.getQueue().size(), getInProcessCount(),
-                  getAbandonedCount(), getUnackedCount());
               executor.submit(() -> {
-                if (tripped) {
+                if (tripped || stopping) {
                   // ABORT REQUEST RECEIVED, ABANDON REQUESTS
                   return;
                 }
+                String messageKey = getMessageHash(topic, message);
+                final java.util.concurrent.atomic.AtomicBoolean shouldProcess =
+                    new java.util.concurrent.atomic.AtomicBoolean(false);
+
+                unackedMessages.compute(messageKey, (key, existingRecord) -> {
+                  if (existingRecord != null
+                      && existingRecord.getState() == MessageState.IN_PROCESS) {
+                    // Message is currently in-flight, skip duplicate processing
+                    return existingRecord;
+                  }
+                  // New message (existingRecord == null) OR previously ABANDONED
+                  // Transition to IN_PROCESS and process
+                  shouldProcess.set(true);
+                  return new MessageRecord(MessageState.IN_PROCESS);
+                });
+
+                if (!shouldProcess.get()) {
+                  logger.warn(
+                      "MQTT message ID {} (key: {}) is already in process."
+                              + " Skipping duplicate execution.",
+                      message.getId(), messageKey);
+                  return;
+                }
+
                 boolean publishInitiated = false;
                 try {
                   byte[] payload = message.getPayload();
@@ -775,25 +767,26 @@ public class MqttToPubSubBridge {
                       pubsubMessageBuilder.putAllAttributes(attributes).build();
 
                   // Publish with 5x retry + exponential backoff
-                  publishWithRetry(publisher, pubsubMessage, message, finalMessageKey,
+                  publishWithRetry(publisher, pubsubMessage, message, messageKey,
                       topic, mqttClient, 1);
                   publishInitiated = true;
                 } catch (Exception e) {
                   logger.warn("Error processing MQTT message", e);
                 } finally {
                   if (!publishInitiated) {
-                    unackedMessages.remove(finalMessageKey);
+                    unackedMessages.remove(messageKey);
                   }
                 }
               });
             } catch (Exception e) {
-              if (messageKey != null) {
-                unackedMessages.remove(messageKey);
-              }
+              String messageKey = getMessageHash(topic, message);
+              // In QoS 1, if executor rejected, message remains unacknowledged in session.
+              // Mark as ABANDONED so the circuit breaker tracks session capacity exhaustion.
+              unackedMessages.put(messageKey, new MessageRecord(MessageState.ABANDONED));
               if (e instanceof RejectedExecutionException) {
                 logger.warn(
-                    "Unable to queue MQTT message ID {} (queue saturated, shedding message"
-                        + " without dropping connection)",
+                    "Unable to queue MQTT message ID {} (queue saturated, marked as ABANDONED"
+                        + " in session)",
                     message.getId(), e);
               } else {
                 logger.error("Error submitting message ID {} to executor", message.getId(), e);

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -790,7 +790,7 @@ class MqttToPubSubBridgeTest {
   }
 
   @Test
-  void testCircuitBreakerTripsWhenThresholdExceeded() throws Exception {
+  void testCircuitBreakerTripsWhenMessageStuck() throws Exception {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
     when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
@@ -814,24 +814,15 @@ class MqttToPubSubBridgeTest {
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
     MqttCallback callback = callbackCaptor.getValue();
 
-    // Start circuit breaker with threshold of 2 messages and 1500ms timeout
-    bridge.startCircuitBreaker(mockMqttClient, 2, 1500L);
+    // Start circuit breaker with high abandoned threshold (100) and 1500ms stuck timeout
+    bridge.startCircuitBreaker(mockMqttClient, 100, 1500L);
 
-    // Send message 1
+    // Send message 1 (which never completes, staying IN_PROCESS)
     MqttMessage msg1 = new MqttMessage("Payload 1".getBytes());
     msg1.setId(101);
     callback.messageArrived(testTopic, msg1);
 
-    // Below threshold (1 < 2)
-    Thread.sleep(2000);
-    org.junit.jupiter.api.Assertions.assertFalse(bridge.isTripped());
-
-    // Send message 2 (reaches threshold 2 >= 2)
-    MqttMessage msg2 = new MqttMessage("Payload 2".getBytes());
-    msg2.setId(102);
-    callback.messageArrived(testTopic, msg2);
-
-    // Wait for timeout (1500ms + polling buffer)
+    // Wait for stuck timeout (1500ms + polling buffer)
     long deadline = System.currentTimeMillis() + 8000;
     while (!bridge.isTripped() && System.currentTimeMillis() < deadline) {
       Thread.sleep(100);
@@ -839,6 +830,74 @@ class MqttToPubSubBridgeTest {
     org.junit.jupiter.api.Assertions.assertTrue(bridge.isTripped());
     org.junit.jupiter.api.Assertions.assertTrue(exited[0]);
     verify(mockMqttClient).disconnectForcibly();
+  }
+
+  @Test
+  void testCircuitBreakerTripsWhenAbandonedThresholdReached() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+
+    final boolean[] exited = new boolean[]{false};
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge() {
+      @Override
+      protected void exit(int status) {
+        exited[0] = true;
+      }
+    };
+
+    // Start circuit breaker with abandoned threshold = 2 and long timeout (60000ms)
+    bridge.startCircuitBreaker(mockMqttClient, 2, 60000L);
+
+    // Add 1 abandoned message (below threshold)
+    bridge.putMessageRecordForTest("msg1",
+        new MqttToPubSubBridge.MessageRecord(MqttToPubSubBridge.MessageState.ABANDONED));
+    Thread.sleep(1500);
+    org.junit.jupiter.api.Assertions.assertFalse(bridge.isTripped());
+
+    // Add 2nd abandoned message (reaches threshold 2 >= 2)
+    bridge.putMessageRecordForTest("msg2",
+        new MqttToPubSubBridge.MessageRecord(MqttToPubSubBridge.MessageState.ABANDONED));
+
+    long deadline = System.currentTimeMillis() + 8000;
+    while (!bridge.isTripped() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(100);
+    }
+    org.junit.jupiter.api.Assertions.assertTrue(bridge.isTripped());
+    org.junit.jupiter.api.Assertions.assertTrue(exited[0]);
+    verify(mockMqttClient).disconnectForcibly();
+  }
+
+  @Test
+  void testCircuitBreakerDoesNotTripUnderHighThroughputSaturation() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+
+    final boolean[] exited = new boolean[]{false};
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge() {
+      @Override
+      protected void exit(int status) {
+        exited[0] = true;
+      }
+    };
+
+    // 1500ms timeout
+    bridge.startCircuitBreaker(mockMqttClient, 100, 1500L);
+
+    // Continuously add and remove messages so count is high but no message exceeds 1500ms
+    long testEnd = System.currentTimeMillis() + 3000;
+    int id = 0;
+    while (System.currentTimeMillis() < testEnd) {
+      String key = "key-" + (++id);
+      bridge.putMessageRecordForTest(key,
+          new MqttToPubSubBridge.MessageRecord(MqttToPubSubBridge.MessageState.IN_PROCESS));
+      Thread.sleep(50);
+      bridge.getMessageState(key);
+      // simulate completion
+      bridge.putMessageRecordForTest(key, null);
+    }
+
+    org.junit.jupiter.api.Assertions.assertFalse(bridge.isTripped());
+    org.junit.jupiter.api.Assertions.assertFalse(exited[0]);
   }
 
   @Test

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -10,6 +10,7 @@ import com.google.api.core.ApiFutures;
 import com.google.bos.udmi.service.support.DataRef;
 import com.google.bos.udmi.service.support.EtcdDataProvider;
 import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.hash.Hashing;
 import com.google.pubsub.v1.PubsubMessage;
 import java.util.Map;
 import org.apache.commons.cli.CommandLine;
@@ -494,7 +495,6 @@ class MqttToPubSubBridgeTest {
     // Publish should NOT be called a second time
     verify(mockPublisher, org.mockito.Mockito.timeout(2000).times(1))
         .publish(any(PubsubMessage.class));
-    assertEquals(1, bridge.getDupCount());
     assertEquals(1, bridge.getUnackedCount());
   }
 
@@ -525,17 +525,17 @@ class MqttToPubSubBridgeTest {
     // 5 attempts expected (exponential backoff up to ~15s)
     verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5))
         .publish(any(PubsubMessage.class));
-    assertEquals(1, bridge.getUnackedCount());
+    Thread.sleep(500);
+    assertEquals(0, bridge.getUnackedCount());
 
     // Now publisher recovers
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFuture("msg-success"));
 
-    // Redelivery arrival of ABANDONED message - should NOT be skipped
+    // Redelivery arrival of failed message - should be retried
     MqttMessage redeliveredMessage = new MqttMessage(payloadStr.getBytes());
     redeliveredMessage.setId(3003);
     redeliveredMessage.setQos(1);
-    redeliveredMessage.setDuplicate(true);
 
     callback.messageArrived(testTopic, redeliveredMessage);
     // Total publish calls should now be 6 (5 initial + 1 redelivery)
@@ -622,27 +622,24 @@ class MqttToPubSubBridgeTest {
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
     MqttCallback callback = callbackCaptor.getValue();
 
-    // First arrival - message is queued and stays IN_PROCESS
+    // First arrival - message is queued and stays in process
     callback.messageArrived(testTopic, mqttMessage);
     verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1))
         .publish(any(PubsubMessage.class));
     assertEquals(1, bridge.getUnackedCount());
 
-    // Second arrival with same ID but isDuplicate=false
-    // (simulating ID wrap-around for a new message)
-    MqttMessage wrappedIdMessage = new MqttMessage(payloadStr.getBytes());
+    // Second arrival with same ID but different payload (ID wrap-around for a new message)
+    MqttMessage wrappedIdMessage = new MqttMessage("New payload after wrap".getBytes());
     wrappedIdMessage.setId(1001);
     wrappedIdMessage.setQos(1);
-    wrappedIdMessage.setDuplicate(false);
 
     callback.messageArrived(testTopic, wrappedIdMessage);
-    // In current buggy code, this is skipped. With fix, publish is called a second time.
     verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(2))
         .publish(any(PubsubMessage.class));
   }
 
   @Test
-  void testSuccessfulTrafficClearsAbandonedMessages() throws Exception {
+  void testFailedTrafficAllowsSubsequentMessages() throws Exception {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
     when(mockMqttClient.getClientId()).thenReturn("test-client");
     String payloadStr = "Hello World";
@@ -655,7 +652,7 @@ class MqttToPubSubBridgeTest {
     mqttMessage2.setQos(1);
 
     Publisher mockPublisher = mock(Publisher.class);
-    // First message fails all 5 attempts -> becomes ABANDONED
+    // First message fails all 5 attempts
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")))
         .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")))
@@ -676,14 +673,108 @@ class MqttToPubSubBridgeTest {
     callback.messageArrived(testTopic, mqttMessage1);
     verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5))
         .publish(any(PubsubMessage.class));
-    assertEquals(1, bridge.getUnackedCount());
+    Thread.sleep(500);
+    assertEquals(0, bridge.getUnackedCount());
 
     // Now second message arrives and succeeds
     callback.messageArrived(testTopic, mqttMessage2);
     verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(6))
         .publish(any(PubsubMessage.class));
 
-    // ABANDONED message 4001 should be cleared upon successful new traffic
+    assertEquals(0, bridge.getUnackedCount());
+  }
+
+  @Test
+  void testQueueWorkersExitImmediatelyWhenTripped() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
+    mqttMessage.setId(6001);
+    mqttMessage.setQos(1);
+
+    String testTopic = "/r/my-registry/d/my-device/events";
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+    bridge.setTrippedForTest(true);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    callback.messageArrived(testTopic, mqttMessage);
+
+    // Verify publisher is never called because bridge is tripped
+    Thread.sleep(1000);
+    verify(mockPublisher, org.mockito.Mockito.never()).publish(any(PubsubMessage.class));
+  }
+
+  @Test
+  void testMessageHashFormat() {
+    String payloadStr = "Test payload for hash";
+    MqttMessage message = new MqttMessage(payloadStr.getBytes());
+    message.setId(777);
+
+    String expectedPayloadHash = Hashing.murmur3_128().hashBytes(payloadStr.getBytes()).toString();
+    String expectedHash = "777:" + expectedPayloadHash;
+
+    assertEquals(expectedHash, MqttToPubSubBridge.getMessageHash(message));
+  }
+
+  @Test
+  void testSameIdDifferentPayloadBothProcessed() throws Exception {
+    final IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    final Publisher mockPublisher = mock(Publisher.class);
+
+    final MqttMessage msg1 = new MqttMessage("Payload One".getBytes());
+    msg1.setId(5050);
+    msg1.setQos(1);
+
+    final MqttMessage msg2 = new MqttMessage("Payload Two".getBytes());
+    msg2.setId(5050);
+    msg2.setQos(1);
+
+    com.google.api.core.SettableApiFuture<String> pendingFuture1 =
+        com.google.api.core.SettableApiFuture.create();
+    com.google.api.core.SettableApiFuture<String> pendingFuture2 =
+        com.google.api.core.SettableApiFuture.create();
+    when(mockPublisher.publish(any(PubsubMessage.class)))
+        .thenReturn(pendingFuture1)
+        .thenReturn(pendingFuture2);
+
+    String testTopic = "/r/my-registry/d/my-device/events";
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    // First message arrives
+    callback.messageArrived(testTopic, msg1);
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1))
+        .publish(any(PubsubMessage.class));
+    assertEquals(1, bridge.getUnackedCount());
+
+    // Second message arrives with same ID but different payload
+    callback.messageArrived(testTopic, msg2);
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(2))
+        .publish(any(PubsubMessage.class));
+    assertEquals(2, bridge.getUnackedCount());
+
+    // Complete msg1
+    pendingFuture1.set("msg-1");
+    // Wait for callback
+    Thread.sleep(500);
+    assertEquals(1, bridge.getUnackedCount());
+
+    // Complete msg2
+    pendingFuture2.set("msg-2");
+    Thread.sleep(500);
     assertEquals(0, bridge.getUnackedCount());
   }
 }

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -824,7 +824,7 @@ class MqttToPubSubBridgeTest {
 
     // Wait for stuck timeout (1500ms + polling buffer)
     long deadline = System.currentTimeMillis() + 8000;
-    while (!bridge.isTripped() && System.currentTimeMillis() < deadline) {
+    while ((!bridge.isTripped() || !exited[0]) && System.currentTimeMillis() < deadline) {
       Thread.sleep(100);
     }
     org.junit.jupiter.api.Assertions.assertTrue(bridge.isTripped());
@@ -859,7 +859,7 @@ class MqttToPubSubBridgeTest {
         new MqttToPubSubBridge.MessageRecord(MqttToPubSubBridge.MessageState.ABANDONED));
 
     long deadline = System.currentTimeMillis() + 8000;
-    while (!bridge.isTripped() && System.currentTimeMillis() < deadline) {
+    while ((!bridge.isTripped() || !exited[0]) && System.currentTimeMillis() < deadline) {
       Thread.sleep(100);
     }
     org.junit.jupiter.api.Assertions.assertTrue(bridge.isTripped());

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -568,5 +568,114 @@ class MqttToPubSubBridgeTest {
     // Verify unacked count popped to 0 after delivery
     assertEquals(0, bridge.getUnackedCount());
   }
+
+  @Test
+  void testProcessingExceptionRemovesFromUnackedMessages() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String testTopic = "/r/my-registry/d/my-device/events";
+
+    MqttMessage badMessage = mock(MqttMessage.class);
+    when(badMessage.getId()).thenReturn(5005);
+    when(badMessage.getPayload()).thenThrow(new RuntimeException("Corrupted payload"));
+
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    callback.messageArrived(testTopic, badMessage);
+    // Wait briefly for executor to process and throw exception
+    Thread.sleep(1000);
+    assertEquals(0, bridge.getUnackedCount());
+  }
+
+  @Test
+  void testIdWrappingDoesNotSkipNewMessage() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String testTopic = "/r/my-registry/d/my-device/events";
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
+    mqttMessage.setId(1001);
+    mqttMessage.setQos(1);
+
+    com.google.api.core.SettableApiFuture<String> pendingFuture =
+        com.google.api.core.SettableApiFuture.create();
+    when(mockPublisher.publish(any(PubsubMessage.class))).thenReturn(pendingFuture);
+
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    // First arrival - message is queued and stays IN_PROCESS
+    callback.messageArrived(testTopic, mqttMessage);
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1)).publish(any(PubsubMessage.class));
+    assertEquals(1, bridge.getUnackedCount());
+
+    // Second arrival with same ID but isDuplicate=false (simulating ID wrap-around for a new message)
+    MqttMessage wrappedIdMessage = new MqttMessage(payloadStr.getBytes());
+    wrappedIdMessage.setId(1001);
+    wrappedIdMessage.setQos(1);
+    wrappedIdMessage.setDuplicate(false);
+
+    callback.messageArrived(testTopic, wrappedIdMessage);
+    // In current buggy code, this is skipped. With fix, publish is called a second time.
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(2)).publish(any(PubsubMessage.class));
+  }
+
+  @Test
+  void testSuccessfulTrafficClearsAbandonedMessages() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String testTopic = "/r/my-registry/d/my-device/events";
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage1 = new MqttMessage(payloadStr.getBytes());
+    mqttMessage1.setId(4001);
+    mqttMessage1.setQos(1);
+
+    final MqttMessage mqttMessage2 = new MqttMessage(payloadStr.getBytes());
+    mqttMessage2.setId(4002);
+    mqttMessage2.setQos(1);
+
+    // First message fails all 5 attempts -> becomes ABANDONED
+    when(mockPublisher.publish(any(PubsubMessage.class)))
+        .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")))
+        .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")))
+        .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")))
+        .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")))
+        .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")))
+        .thenReturn(ApiFutures.immediateFuture("msg-success"));
+
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    callback.messageArrived(testTopic, mqttMessage1);
+    verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5)).publish(any(PubsubMessage.class));
+    assertEquals(1, bridge.getUnackedCount());
+
+    // Now second message arrives and succeeds
+    callback.messageArrived(testTopic, mqttMessage2);
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(6)).publish(any(PubsubMessage.class));
+
+    // ABANDONED message 4001 should be cleared upon successful new traffic
+    assertEquals(0, bridge.getUnackedCount());
+  }
 }
+
 

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -526,13 +526,18 @@ class MqttToPubSubBridgeTest {
     verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5))
         .publish(any(PubsubMessage.class));
     Thread.sleep(500);
-    assertEquals(0, bridge.getUnackedCount());
+    // After 5 failed attempts, message is marked as ABANDONED and stays unacked
+    assertEquals(1, bridge.getUnackedCount());
+    assertEquals(1, bridge.getAbandonedCount());
+    assertEquals(0, bridge.getInProcessCount());
+    assertEquals(MqttToPubSubBridge.MessageState.ABANDONED,
+        bridge.getMessageState(MqttToPubSubBridge.getMessageHash(testTopic, mqttMessage)));
 
     // Now publisher recovers
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFuture("msg-success"));
 
-    // Redelivery arrival of failed message - should be retried
+    // Redelivery arrival of failed message - should be requeued and retried
     MqttMessage redeliveredMessage = new MqttMessage(payloadStr.getBytes());
     redeliveredMessage.setId(3003);
     redeliveredMessage.setQos(1);
@@ -543,6 +548,7 @@ class MqttToPubSubBridgeTest {
         .publish(any(PubsubMessage.class));
     // After success, unacked count should be 0
     assertEquals(0, bridge.getUnackedCount());
+    assertEquals(0, bridge.getAbandonedCount());
   }
 
   @Test
@@ -674,14 +680,18 @@ class MqttToPubSubBridgeTest {
     verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5))
         .publish(any(PubsubMessage.class));
     Thread.sleep(500);
-    assertEquals(0, bridge.getUnackedCount());
+    // Message 1 is marked as ABANDONED (still counted in unackedMessages)
+    assertEquals(1, bridge.getUnackedCount());
+    assertEquals(1, bridge.getAbandonedCount());
 
     // Now second message arrives and succeeds
     callback.messageArrived(testTopic, mqttMessage2);
     verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(6))
         .publish(any(PubsubMessage.class));
 
-    assertEquals(0, bridge.getUnackedCount());
+    // Message 2 succeeded and removed, Message 1 remains abandoned
+    assertEquals(1, bridge.getUnackedCount());
+    assertEquals(1, bridge.getAbandonedCount());
   }
 
   @Test
@@ -721,6 +731,7 @@ class MqttToPubSubBridgeTest {
     String expectedHash = "777:" + expectedPayloadHash;
 
     assertEquals(expectedHash, MqttToPubSubBridge.getMessageHash(message));
+    assertEquals("/topic:" + expectedHash, MqttToPubSubBridge.getMessageHash("/topic", message));
   }
 
   @Test
@@ -776,6 +787,54 @@ class MqttToPubSubBridgeTest {
     pendingFuture2.set("msg-2");
     Thread.sleep(500);
     assertEquals(0, bridge.getUnackedCount());
+  }
+
+  @Test
+  void testCircuitBreakerTripsWhenThresholdExceeded() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    Publisher mockPublisher = mock(Publisher.class);
+    com.google.api.core.SettableApiFuture<String> pendingFuture =
+        com.google.api.core.SettableApiFuture.create();
+    when(mockPublisher.publish(any(PubsubMessage.class))).thenReturn(pendingFuture);
+
+    final boolean[] exited = new boolean[]{false};
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge() {
+      @Override
+      protected void exit(int status) {
+        exited[0] = true;
+      }
+    };
+
+    String testTopic = "/r/my-registry/d/my-device/events";
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    // Start circuit breaker with threshold of 2 messages and 1500ms timeout
+    bridge.startCircuitBreaker(mockMqttClient, 2, 1500L);
+
+    // Send message 1
+    MqttMessage msg1 = new MqttMessage("Payload 1".getBytes());
+    msg1.setId(101);
+    callback.messageArrived(testTopic, msg1);
+
+    // Below threshold (1 < 2)
+    Thread.sleep(2000);
+    org.junit.jupiter.api.Assertions.assertFalse(bridge.isTripped());
+
+    // Send message 2 (reaches threshold 2 >= 2)
+    MqttMessage msg2 = new MqttMessage("Payload 2".getBytes());
+    msg2.setId(102);
+    callback.messageArrived(testTopic, msg2);
+
+    // Wait for timeout (1500ms + buffer)
+    Thread.sleep(2500);
+    org.junit.jupiter.api.Assertions.assertTrue(bridge.isTripped());
+    org.junit.jupiter.api.Assertions.assertTrue(exited[0]);
+    verify(mockMqttClient).disconnect();
   }
 }
 

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -3,7 +3,6 @@ package com.google.bos.udmi.service.bridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -451,7 +450,8 @@ class MqttToPubSubBridgeTest {
     callback.messageArrived(testTopic, mqttMessage);
 
     // Verify publish was called twice due to retry
-    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(2)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(2))
+        .publish(any(PubsubMessage.class));
   }
 
   @Test
@@ -459,7 +459,6 @@ class MqttToPubSubBridgeTest {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
     when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
-    String testTopic = "/r/my-registry/d/my-device/events";
     String payloadStr = "Hello World";
     final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
     mqttMessage.setId(1001);
@@ -470,6 +469,7 @@ class MqttToPubSubBridgeTest {
         com.google.api.core.SettableApiFuture.create();
     when(mockPublisher.publish(any(PubsubMessage.class))).thenReturn(pendingFuture);
 
+    String testTopic = "/r/my-registry/d/my-device/events";
     MqttToPubSubBridge bridge = new MqttToPubSubBridge();
     bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
@@ -480,7 +480,8 @@ class MqttToPubSubBridgeTest {
 
     // First arrival - message is queued and stays IN_PROCESS
     callback.messageArrived(testTopic, mqttMessage);
-    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1))
+        .publish(any(PubsubMessage.class));
     assertEquals(1, bridge.getUnackedCount());
 
     // Second arrival while IN_PROCESS - should skip queue
@@ -491,7 +492,8 @@ class MqttToPubSubBridgeTest {
 
     callback.messageArrived(testTopic, dupMessage);
     // Publish should NOT be called a second time
-    verify(mockPublisher, org.mockito.Mockito.timeout(2000).times(1)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(2000).times(1))
+        .publish(any(PubsubMessage.class));
     assertEquals(1, bridge.getDupCount());
     assertEquals(1, bridge.getUnackedCount());
   }
@@ -501,7 +503,6 @@ class MqttToPubSubBridgeTest {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
     when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
-    String testTopic = "/r/my-registry/d/my-device/events";
     String payloadStr = "Hello World";
     final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
     mqttMessage.setId(3003);
@@ -511,6 +512,7 @@ class MqttToPubSubBridgeTest {
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")));
 
+    String testTopic = "/r/my-registry/d/my-device/events";
     MqttToPubSubBridge bridge = new MqttToPubSubBridge();
     bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
@@ -521,7 +523,8 @@ class MqttToPubSubBridgeTest {
 
     callback.messageArrived(testTopic, mqttMessage);
     // 5 attempts expected (exponential backoff up to ~15s)
-    verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5))
+        .publish(any(PubsubMessage.class));
     assertEquals(1, bridge.getUnackedCount());
 
     // Now publisher recovers
@@ -536,7 +539,8 @@ class MqttToPubSubBridgeTest {
 
     callback.messageArrived(testTopic, redeliveredMessage);
     // Total publish calls should now be 6 (5 initial + 1 redelivery)
-    verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(6)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(6))
+        .publish(any(PubsubMessage.class));
     // After success, unacked count should be 0
     assertEquals(0, bridge.getUnackedCount());
   }
@@ -546,7 +550,6 @@ class MqttToPubSubBridgeTest {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
     when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
-    String testTopic = "/r/my-registry/d/my-device/events";
     String payloadStr = "Hello World";
     final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
     mqttMessage.setId(2002);
@@ -555,6 +558,7 @@ class MqttToPubSubBridgeTest {
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFuture("msg-123"));
 
+    String testTopic = "/r/my-registry/d/my-device/events";
     MqttToPubSubBridge bridge = new MqttToPubSubBridge();
     bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
@@ -564,7 +568,8 @@ class MqttToPubSubBridgeTest {
     MqttCallback callback = callbackCaptor.getValue();
 
     callback.messageArrived(testTopic, mqttMessage);
-    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1))
+        .publish(any(PubsubMessage.class));
     // Verify unacked count popped to 0 after delivery
     assertEquals(0, bridge.getUnackedCount());
   }
@@ -599,7 +604,6 @@ class MqttToPubSubBridgeTest {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
     when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
-    String testTopic = "/r/my-registry/d/my-device/events";
     String payloadStr = "Hello World";
     final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
     mqttMessage.setId(1001);
@@ -609,6 +613,7 @@ class MqttToPubSubBridgeTest {
         com.google.api.core.SettableApiFuture.create();
     when(mockPublisher.publish(any(PubsubMessage.class))).thenReturn(pendingFuture);
 
+    String testTopic = "/r/my-registry/d/my-device/events";
     MqttToPubSubBridge bridge = new MqttToPubSubBridge();
     bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
@@ -619,10 +624,12 @@ class MqttToPubSubBridgeTest {
 
     // First arrival - message is queued and stays IN_PROCESS
     callback.messageArrived(testTopic, mqttMessage);
-    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1))
+        .publish(any(PubsubMessage.class));
     assertEquals(1, bridge.getUnackedCount());
 
-    // Second arrival with same ID but isDuplicate=false (simulating ID wrap-around for a new message)
+    // Second arrival with same ID but isDuplicate=false
+    // (simulating ID wrap-around for a new message)
     MqttMessage wrappedIdMessage = new MqttMessage(payloadStr.getBytes());
     wrappedIdMessage.setId(1001);
     wrappedIdMessage.setQos(1);
@@ -630,15 +637,14 @@ class MqttToPubSubBridgeTest {
 
     callback.messageArrived(testTopic, wrappedIdMessage);
     // In current buggy code, this is skipped. With fix, publish is called a second time.
-    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(2)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(2))
+        .publish(any(PubsubMessage.class));
   }
 
   @Test
   void testSuccessfulTrafficClearsAbandonedMessages() throws Exception {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
     when(mockMqttClient.getClientId()).thenReturn("test-client");
-    Publisher mockPublisher = mock(Publisher.class);
-    String testTopic = "/r/my-registry/d/my-device/events";
     String payloadStr = "Hello World";
     final MqttMessage mqttMessage1 = new MqttMessage(payloadStr.getBytes());
     mqttMessage1.setId(4001);
@@ -648,6 +654,7 @@ class MqttToPubSubBridgeTest {
     mqttMessage2.setId(4002);
     mqttMessage2.setQos(1);
 
+    Publisher mockPublisher = mock(Publisher.class);
     // First message fails all 5 attempts -> becomes ABANDONED
     when(mockPublisher.publish(any(PubsubMessage.class)))
         .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")))
@@ -657,6 +664,7 @@ class MqttToPubSubBridgeTest {
         .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")))
         .thenReturn(ApiFutures.immediateFuture("msg-success"));
 
+    String testTopic = "/r/my-registry/d/my-device/events";
     MqttToPubSubBridge bridge = new MqttToPubSubBridge();
     bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
 
@@ -666,12 +674,14 @@ class MqttToPubSubBridgeTest {
     MqttCallback callback = callbackCaptor.getValue();
 
     callback.messageArrived(testTopic, mqttMessage1);
-    verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5))
+        .publish(any(PubsubMessage.class));
     assertEquals(1, bridge.getUnackedCount());
 
     // Now second message arrives and succeeds
     callback.messageArrived(testTopic, mqttMessage2);
-    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(6)).publish(any(PubsubMessage.class));
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(6))
+        .publish(any(PubsubMessage.class));
 
     // ABANDONED message 4001 should be cleared upon successful new traffic
     assertEquals(0, bridge.getUnackedCount());

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -3,6 +3,7 @@ package com.google.bos.udmi.service.bridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -421,6 +422,104 @@ class MqttToPubSubBridgeTest {
     CommandLine commandLine = MqttToPubSubBridge.parseArgs(args);
     String etcdOptions = MqttToPubSubBridge.getEtcdOptions(commandLine);
     assertEquals("ca_file=/path/to/ca.crt", etcdOptions);
+  }
+
+  @Test
+  void testSetupBridgePublishRetry() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String testTopic = "/r/my-registry/d/my-device/events";
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
+
+    // Mock publisher to fail on first attempt, succeed on second attempt
+    when(mockPublisher.publish(any(PubsubMessage.class)))
+        .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("Transient failure")))
+        .thenReturn(ApiFutures.immediateFuture("msg-123"));
+
+    // Call setupBridge
+    new MqttToPubSubBridge().setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    // Capture callback
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    // Simulate message arrival
+    callback.messageArrived(testTopic, mqttMessage);
+
+    // Verify publish was called twice due to retry
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(2)).publish(any(PubsubMessage.class));
+  }
+
+  @Test
+  void testDuplicateMessageTrackingAndDeduplication() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String testTopic = "/r/my-registry/d/my-device/events";
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
+    mqttMessage.setId(1001);
+    mqttMessage.setQos(1);
+
+    when(mockPublisher.publish(any(PubsubMessage.class)))
+        .thenReturn(ApiFutures.immediateFuture("msg-123"));
+
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    // First arrival - normal message
+    callback.messageArrived(testTopic, mqttMessage);
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1)).publish(any(PubsubMessage.class));
+    assertEquals(0, bridge.getDupCount());
+
+    // Second arrival - duplicate message (DUP flag set to true)
+    MqttMessage dupMessage = new MqttMessage(payloadStr.getBytes());
+    dupMessage.setId(1001);
+    dupMessage.setQos(1);
+    dupMessage.setDuplicate(true);
+
+    callback.messageArrived(testTopic, dupMessage);
+    // Should ACK without calling publish again
+    verify(mockPublisher, org.mockito.Mockito.timeout(3000).times(1)).publish(any(PubsubMessage.class));
+    assertEquals(1, bridge.getDupCount());
+    assertEquals(0, bridge.getUnackedCount());
+  }
+
+  @Test
+  void testUnackedMessagesMapTracking() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String testTopic = "/r/my-registry/d/my-device/events";
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
+    mqttMessage.setId(2002);
+    mqttMessage.setQos(1);
+
+    when(mockPublisher.publish(any(PubsubMessage.class)))
+        .thenReturn(ApiFutures.immediateFuture("msg-123"));
+
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    callback.messageArrived(testTopic, mqttMessage);
+    verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1)).publish(any(PubsubMessage.class));
+    // Verify unacked count popped to 0 after delivery
+    assertEquals(0, bridge.getUnackedCount());
   }
 }
 

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -1029,6 +1029,20 @@ class MqttToPubSubBridgeTest {
     String expectedKey = MqttToPubSubBridge.getMessageHash(testTopic, mqttMessage);
     assertEquals(MqttToPubSubBridge.MessageState.ABANDONED, bridge.getMessageState(expectedKey));
   }
+
+  @Test
+  void testStartPeriodicReconnect() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.isConnected()).thenReturn(true);
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+
+    // Call startPeriodicReconnect with 1 second interval
+    bridge.startPeriodicReconnect(mockMqttClient, 1);
+
+    // Verify disconnect(1000L) and reconnect() are called
+    verify(mockMqttClient, org.mockito.Mockito.timeout(5000)).disconnect(1000L);
+    verify(mockMqttClient, org.mockito.Mockito.timeout(5000)).reconnect();
+  }
 }
 
 

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -455,7 +455,7 @@ class MqttToPubSubBridgeTest {
   }
 
   @Test
-  void testDuplicateMessageTrackingAndDeduplication() throws Exception {
+  void testInProcessMessageSkipsQueue() throws Exception {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
     when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
@@ -465,8 +465,10 @@ class MqttToPubSubBridgeTest {
     mqttMessage.setId(1001);
     mqttMessage.setQos(1);
 
-    when(mockPublisher.publish(any(PubsubMessage.class)))
-        .thenReturn(ApiFutures.immediateFuture("msg-123"));
+    // Return a never-completing future so the message stays IN_PROCESS
+    com.google.api.core.SettableApiFuture<String> pendingFuture =
+        com.google.api.core.SettableApiFuture.create();
+    when(mockPublisher.publish(any(PubsubMessage.class))).thenReturn(pendingFuture);
 
     MqttToPubSubBridge bridge = new MqttToPubSubBridge();
     bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
@@ -476,21 +478,66 @@ class MqttToPubSubBridgeTest {
     verify(mockMqttClient).setCallback(callbackCaptor.capture());
     MqttCallback callback = callbackCaptor.getValue();
 
-    // First arrival - normal message
+    // First arrival - message is queued and stays IN_PROCESS
     callback.messageArrived(testTopic, mqttMessage);
     verify(mockPublisher, org.mockito.Mockito.timeout(5000).times(1)).publish(any(PubsubMessage.class));
-    assertEquals(0, bridge.getDupCount());
+    assertEquals(1, bridge.getUnackedCount());
 
-    // Second arrival - duplicate message (DUP flag set to true)
+    // Second arrival while IN_PROCESS - should skip queue
     MqttMessage dupMessage = new MqttMessage(payloadStr.getBytes());
     dupMessage.setId(1001);
     dupMessage.setQos(1);
     dupMessage.setDuplicate(true);
 
     callback.messageArrived(testTopic, dupMessage);
-    // Should ACK without calling publish again
-    verify(mockPublisher, org.mockito.Mockito.timeout(3000).times(1)).publish(any(PubsubMessage.class));
+    // Publish should NOT be called a second time
+    verify(mockPublisher, org.mockito.Mockito.timeout(2000).times(1)).publish(any(PubsubMessage.class));
     assertEquals(1, bridge.getDupCount());
+    assertEquals(1, bridge.getUnackedCount());
+  }
+
+  @Test
+  void testAbandonedMessageRequeuesOnRedelivery() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String testTopic = "/r/my-registry/d/my-device/events";
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
+    mqttMessage.setId(3003);
+    mqttMessage.setQos(1);
+
+    // Publisher fails all 5 retries
+    when(mockPublisher.publish(any(PubsubMessage.class)))
+        .thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("PubSub Outage")));
+
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    callback.messageArrived(testTopic, mqttMessage);
+    // 5 attempts expected (exponential backoff up to ~15s)
+    verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(5)).publish(any(PubsubMessage.class));
+    assertEquals(1, bridge.getUnackedCount());
+
+    // Now publisher recovers
+    when(mockPublisher.publish(any(PubsubMessage.class)))
+        .thenReturn(ApiFutures.immediateFuture("msg-success"));
+
+    // Redelivery arrival of ABANDONED message - should NOT be skipped
+    MqttMessage redeliveredMessage = new MqttMessage(payloadStr.getBytes());
+    redeliveredMessage.setId(3003);
+    redeliveredMessage.setQos(1);
+    redeliveredMessage.setDuplicate(true);
+
+    callback.messageArrived(testTopic, redeliveredMessage);
+    // Total publish calls should now be 6 (5 initial + 1 redelivery)
+    verify(mockPublisher, org.mockito.Mockito.timeout(20000).times(6)).publish(any(PubsubMessage.class));
+    // After success, unacked count should be 0
     assertEquals(0, bridge.getUnackedCount());
   }
 

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -887,6 +887,58 @@ class MqttToPubSubBridgeTest {
     org.junit.jupiter.api.Assertions.assertTrue(
         cleanStartAliasCommandLine.hasOption("clean_start"));
   }
+
+  @Test
+  void testGracefulShutdown() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.isConnected()).thenReturn(true);
+    Publisher mockPublisher = mock(Publisher.class);
+    when(mockPublisher.awaitTermination(any(Long.class), any(java.util.concurrent.TimeUnit.class)))
+        .thenReturn(true);
+    EtcdDataProvider mockEtcdProvider = mock(EtcdDataProvider.class);
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+
+    MqttToPubSubBridge.gracefulShutdown(
+        bridge, mockMqttClient, mockPublisher, mockEtcdProvider);
+
+    verify(mockMqttClient).disconnect();
+    verify(mockPublisher).shutdown();
+    verify(mockPublisher).awaitTermination(10, java.util.concurrent.TimeUnit.SECONDS);
+    verify(mockEtcdProvider).shutdown();
+  }
+
+  @Test
+  void testBridgeShutdownWithTimeout() {
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.shutdown(2, java.util.concurrent.TimeUnit.SECONDS);
+  }
+
+  @Test
+  void testQueueWorkersExitImmediatelyWhenStopping() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
+    mqttMessage.setId(6002);
+    mqttMessage.setQos(1);
+
+    String testTopic = "/r/my-registry/d/my-device/events";
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+    bridge.setStopping(true);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    callback.messageArrived(testTopic, mqttMessage);
+
+    // Verify publisher is never called because bridge is stopping
+    Thread.sleep(1000);
+    verify(mockPublisher, org.mockito.Mockito.never()).publish(any(PubsubMessage.class));
+  }
 }
 
 

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -998,6 +998,37 @@ class MqttToPubSubBridgeTest {
     Thread.sleep(1000);
     verify(mockPublisher, org.mockito.Mockito.never()).publish(any(PubsubMessage.class));
   }
+
+  @Test
+  void testRejectedExecutionMarksMessageAbandoned() throws Exception {
+    IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
+    Publisher mockPublisher = mock(Publisher.class);
+    String payloadStr = "Hello World";
+    final MqttMessage mqttMessage = new MqttMessage(payloadStr.getBytes());
+    mqttMessage.setId(7007);
+    mqttMessage.setQos(1);
+
+    String testTopic = "/r/my-registry/d/my-device/events";
+    MqttToPubSubBridge bridge = new MqttToPubSubBridge();
+    bridge.setupBridge(mockMqttClient, mockPublisher, testTopic, null);
+
+    // Shut down executor to trigger RejectedExecutionException upon messageArrived
+    bridge.shutdown(100, java.util.concurrent.TimeUnit.MILLISECONDS);
+
+    ArgumentCaptor<MqttCallback> callbackCaptor =
+        ArgumentCaptor.forClass(MqttCallback.class);
+    verify(mockMqttClient).setCallback(callbackCaptor.capture());
+    MqttCallback callback = callbackCaptor.getValue();
+
+    callback.messageArrived(testTopic, mqttMessage);
+
+    // Verify message is recorded as ABANDONED in session
+    assertEquals(1, bridge.getUnackedCount());
+    assertEquals(1, bridge.getAbandonedCount());
+    String expectedKey = MqttToPubSubBridge.getMessageHash(testTopic, mqttMessage);
+    assertEquals(MqttToPubSubBridge.MessageState.ABANDONED, bridge.getMessageState(expectedKey));
+  }
 }
 
 

--- a/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
+++ b/udmis/src/test/java/com/google/bos/udmi/service/bridge/MqttToPubSubBridgeTest.java
@@ -792,6 +792,7 @@ class MqttToPubSubBridgeTest {
   @Test
   void testCircuitBreakerTripsWhenThresholdExceeded() throws Exception {
     IMqttClient mockMqttClient = mock(IMqttClient.class);
+    when(mockMqttClient.getClientId()).thenReturn("test-client");
     Publisher mockPublisher = mock(Publisher.class);
     com.google.api.core.SettableApiFuture<String> pendingFuture =
         com.google.api.core.SettableApiFuture.create();
@@ -830,11 +831,61 @@ class MqttToPubSubBridgeTest {
     msg2.setId(102);
     callback.messageArrived(testTopic, msg2);
 
-    // Wait for timeout (1500ms + buffer)
-    Thread.sleep(2500);
+    // Wait for timeout (1500ms + polling buffer)
+    long deadline = System.currentTimeMillis() + 8000;
+    while (!bridge.isTripped() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(100);
+    }
     org.junit.jupiter.api.Assertions.assertTrue(bridge.isTripped());
     org.junit.jupiter.api.Assertions.assertTrue(exited[0]);
-    verify(mockMqttClient).disconnect();
+    verify(mockMqttClient).disconnectForcibly();
+  }
+
+  @Test
+  void testParseArgsCircuitBreakerOptions() throws Exception {
+    String[] args = {
+        "--gcp_project_id=my-project",
+        "--pubsub_topic_id=my-topic",
+        "--mqtt_client_id=my-client",
+        "--circuit_breaker_unacked_threshold=50",
+        "--circuit_breaker_timeout_sec=120"
+    };
+    CommandLine commandLine = MqttToPubSubBridge.parseArgs(args);
+    assertEquals("50", commandLine.getOptionValue("circuit_breaker_unacked_threshold"));
+    assertEquals("120", commandLine.getOptionValue("circuit_breaker_timeout_sec"));
+  }
+
+  @Test
+  void testParseArgsCleanStartOptions() throws Exception {
+    String[] defaultArgs = {
+        "--gcp_project_id=my-project",
+        "--pubsub_topic_id=my-topic",
+        "--mqtt_client_id=my-client"
+    };
+    CommandLine defaultCommandLine = MqttToPubSubBridge.parseArgs(defaultArgs);
+    org.junit.jupiter.api.Assertions.assertFalse(
+        defaultCommandLine.hasOption("mqtt_clean_start")
+            || defaultCommandLine.hasOption("clean_start"));
+
+    String[] cleanStartArgs = {
+        "--gcp_project_id=my-project",
+        "--pubsub_topic_id=my-topic",
+        "--mqtt_client_id=my-client",
+        "--mqtt_clean_start"
+    };
+    CommandLine cleanStartCommandLine = MqttToPubSubBridge.parseArgs(cleanStartArgs);
+    org.junit.jupiter.api.Assertions.assertTrue(
+        cleanStartCommandLine.hasOption("mqtt_clean_start"));
+
+    String[] cleanStartAliasArgs = {
+        "--gcp_project_id=my-project",
+        "--pubsub_topic_id=my-topic",
+        "--mqtt_client_id=my-client",
+        "--clean_start"
+    };
+    CommandLine cleanStartAliasCommandLine = MqttToPubSubBridge.parseArgs(cleanStartAliasArgs);
+    org.junit.jupiter.api.Assertions.assertTrue(
+        cleanStartAliasCommandLine.hasOption("clean_start"));
   }
 }
 


### PR DESCRIPTION
The logic arround unacked messages/termination is flawed, this fixes those assumptions whilst keeping with the strategy:
1 - Circuit breaker considers "abandoned/unacked" messages as well as oldest message being "process" 
2 - add a reconnect so unacked messages can get redelivered
3 - in thread retries of Pub/Sub message delivery
4 - graceful termination